### PR TITLE
OPHJOD-164: add react-hook-form dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "i18next": "^23.7.18",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.50.1",
         "react-i18next": "^14.0.1",
         "react-router-dom": "^6.21.3"
       },
@@ -18271,6 +18272,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.50.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
+      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
     },
     "node_modules/react-i18next": {
       "version": "14.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "i18next": "^23.7.18",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.50.1",
     "react-i18next": "^14.0.1",
     "react-router-dom": "^6.21.3"
   },


### PR DESCRIPTION
## Description

Added [react-hook-form ](https://react-hook-form.com/) dependency for forms. 

_Performant, flexible and extensible forms with easy-to-use validation._

Includes basic validation possibilities, but other validation libraries can be also added if needed in the future, e.g. [Zod](https://zod.dev/)

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-164
