### PR TITLE
OPHJOD-499: Add border and padding props from SimpleNavigationList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,7 +1658,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#ea401e5ed12110c64296b044d39192abe123aee2",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#99426fa39f6ce57df9066198e18680a7907b2b7a",
+      "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^3.0.0-1",
         "@floating-ui/react": "^0.26.12",

--- a/src/components/MainLayout/SimpleNavigationList.tsx
+++ b/src/components/MainLayout/SimpleNavigationList.tsx
@@ -5,12 +5,22 @@ interface SimpleNavigationListProps {
   title: string;
   collapsible?: boolean;
   children: React.ReactNode;
+  borderEnabled?: boolean;
+  addPadding?: boolean;
 }
 
-export const SimpleNavigationList = ({ title, collapsible = false, children }: SimpleNavigationListProps) => {
+export const SimpleNavigationList = ({
+  title,
+  collapsible = false,
+  children,
+  borderEnabled = true,
+  addPadding = true,
+}: SimpleNavigationListProps) => {
   const { i18n, t } = useTranslation();
+  const borderClassName = borderEnabled ? 'rounded-[20px] border-[3px] border-solid border-secondary-gray' : '';
+  const paddingClassName = addPadding ? 'py-6 px-[20px]' : '';
   return (
-    <div className="rounded-[20px] border-[3px] border-solid border-secondary-gray bg-white px-[20px] py-6">
+    <div className={`${borderClassName} bg-white ${paddingClassName}`.trim()}>
       {collapsible ? (
         <Accordion
           title={title}

--- a/src/routes/Tool/Competences.tsx
+++ b/src/routes/Tool/Competences.tsx
@@ -34,15 +34,17 @@ const Filters = ({
   setKeyFigure,
   order,
   setOrder,
+  isMobile,
 }: {
   keyFigure: string;
   setKeyFigure: (val: string) => void;
   order: string;
   setOrder: (val: string) => void;
+  isMobile: boolean;
 }) => {
   return (
-    <div className="flex flex-col gap-6 sm:gap-5">
-      <SimpleNavigationList title="Tunnusluvut" collapsible>
+    <div className="inline-flex flex-col gap-6 sm:gap-5 w-full">
+      <SimpleNavigationList title="Tunnusluvut" collapsible borderEnabled={isMobile} addPadding={isMobile}>
         <RadioButtonGroup
           label="Valitse näytettävä tunnusluku. Vaihtoehdot riippuvat hakutuloksistasi."
           value={keyFigure}
@@ -56,7 +58,7 @@ const Filters = ({
           <RadioButton label="Työttömyysprosentti" value="e" />
         </RadioButtonGroup>
       </SimpleNavigationList>
-      <SimpleNavigationList title="Järjestys" collapsible>
+      <SimpleNavigationList title="Järjestys" collapsible borderEnabled={isMobile} addPadding={isMobile}>
         <RadioButtonGroup
           label="Valitse järjestystapa. Tulokset järjestetään valitun tunnusluvun mukaan."
           value={order}
@@ -191,7 +193,13 @@ const Competences = () => {
                   open={showFilters}
                   onClose={() => setShowFilters(false)}
                   content={
-                    <Filters keyFigure={keyFigure} setKeyFigure={setKeyFigure} order={order} setOrder={setOrder} />
+                    <Filters
+                      keyFigure={keyFigure}
+                      setKeyFigure={setKeyFigure}
+                      order={order}
+                      setOrder={setOrder}
+                      isMobile={sm}
+                    />
                   }
                   footer={
                     <div className="flex flex-row justify-end gap-4">
@@ -210,7 +218,13 @@ const Competences = () => {
         </div>
         {sm && (
           <div className="col-span-2 sm:mt-8">
-            <Filters keyFigure={keyFigure} setKeyFigure={setKeyFigure} order={order} setOrder={setOrder} />
+            <Filters
+              keyFigure={keyFigure}
+              setKeyFigure={setKeyFigure}
+              order={order}
+              setOrder={setOrder}
+              isMobile={sm}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add new optional props for the SimpleNavigationList.

On mobile it was required to have a a borderless and non-padding version. I thought to have to separate props instead of just e.g `mobile` for now as it might be beneficial to have them separate.

Names of the props can be changed.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-499
