### PR TITLE
OPHJOD-519: Remove void's usage from Modal onClose prop as it is now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,7 +1658,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#b5067b95f636f079f8912d346249e4980a29467e",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#4787e80a80dfd219d900c5641e244428639f809c",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^3.0.0-1",

--- a/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
@@ -218,7 +218,6 @@ const EducationHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: EducationHis
   return !isLoading ? (
     <Modal
       open={isOpen}
-      onClose={() => void {}}
       content={
         <FormProvider {...methods}>
           <Form

--- a/src/routes/Profile/FreeTimeActivities/FreeTimeActivitiesWizard/FreeTimeActivitiesWizard.tsx
+++ b/src/routes/Profile/FreeTimeActivities/FreeTimeActivitiesWizard/FreeTimeActivitiesWizard.tsx
@@ -17,7 +17,6 @@ const FreeTimeActivitiesWizard = ({ isOpen, setIsOpen }: FreeTimeActivitiesWizar
   return !isLoading ? (
     <Modal
       open={isOpen}
-      onClose={() => void {}}
       content={
         <div>
           <h1>FreeTimeActivitiesWizard</h1>

--- a/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
@@ -190,7 +190,6 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
   return !isLoading ? (
     <Modal
       open={isOpen}
-      onClose={() => void {}}
       content={
         <FormProvider {...methods}>
           <Form


### PR DESCRIPTION
optional

<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Removes the use of **voids** for Modal's `onClose` prop as it is now optional.

Requires the DS PR: Opetushallitus/jod-design-system/pull/81

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-519
