### PR TITLE
OPHJOD-538: Refactor profile API (part 1)

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -30,7 +30,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/profiili/koulutukset': {
+  '/api/profiili/koulutuskokonaisuudet': {
     parameters: {
       query?: never;
       header?: never;
@@ -38,37 +38,37 @@ export interface paths {
       cookie?: never;
     };
     /** Get all koulutukset and kategoriat of the user */
-    get: operations['koulutusFind'];
+    get: operations['koulutusKokonaisuusFindAll'];
     /**
      * Updates a set of Koulutus
      * @description If an existing Koulutus in a Kategoria is omitted, it will be removed.
      */
-    put: operations['koulutusUpdate'];
+    put: operations['koulutusKokonaisuusUpdate'];
     /** Creates a set of Koulutus associated with an optional Kategoria, creating the Kategoria if necessary */
-    post: operations['koulutusAdd'];
-    delete: operations['koulutusDeleteAll'];
+    post: operations['koulutusKokonaisuusAdd'];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
     trace?: never;
   };
-  '/api/profiili/koulutukset/{id}': {
+  '/api/profiili/koulutuskokonaisuudet/koulutukset/{id}': {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    get: operations['koulutusGet'];
-    put: operations['koulutusUpdateKoulutus'];
+    get: operations['koulutusKokonaisuusGetKoulutus'];
+    put: operations['koulutusKokonaisuusUpdateKoulutus'];
     post?: never;
-    delete: operations['koulutusDelete'];
+    delete: operations['koulutusKokonaisuusDeleteKoulutus'];
     options?: never;
     head?: never;
     patch?: never;
     trace?: never;
   };
-  '/api/profiili/koulutukset/kategoriat/{id}': {
+  '/api/profiili/koulutuskokonaisuudet/kategoriat/{id}': {
     parameters: {
       query?: never;
       header?: never;
@@ -76,7 +76,7 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
-    put: operations['koulutusUpdateKategoria'];
+    put: operations['koulutusKokonaisuusUpdateKategoria'];
     post?: never;
     delete?: never;
     options?: never;
@@ -295,14 +295,14 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/profiili/koulutukset/kategoriat': {
+  '/api/profiili/koulutuskokonaisuudet/kategoriat': {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    get: operations['koulutusGetKategoriat'];
+    get: operations['koulutusKokonaisuusGetKategoriat'];
     put?: never;
     post?: never;
     delete?: never;
@@ -370,6 +370,26 @@ export interface paths {
     put?: never;
     post?: never;
     delete: operations['yksilonOsaaminenDelete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/profiili/koulutuskokonaisuudet/koulutukset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Deletes one or more Koulutus by ID
+     * @description Possible resulting empty Kategoria are alse removed.
+     */
+    delete: operations['koulutusKokonaisuusDeleteKoulutukset'];
     options?: never;
     head?: never;
     patch?: never;
@@ -596,9 +616,11 @@ export interface operations {
       };
     };
   };
-  koulutusFind: {
+  koulutusKokonaisuusFindAll: {
     parameters: {
-      query?: never;
+      query?: {
+        kategoria?: string;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -616,7 +638,7 @@ export interface operations {
       };
     };
   };
-  koulutusUpdate: {
+  koulutusKokonaisuusUpdate: {
     parameters: {
       query?: never;
       header?: never;
@@ -640,7 +662,7 @@ export interface operations {
       };
     };
   };
-  koulutusAdd: {
+  koulutusKokonaisuusAdd: {
     parameters: {
       query?: never;
       header?: never;
@@ -664,27 +686,7 @@ export interface operations {
       };
     };
   };
-  koulutusDeleteAll: {
-    parameters: {
-      query: {
-        ids: string[];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description No Content */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  koulutusGet: {
+  koulutusKokonaisuusGetKoulutus: {
     parameters: {
       query?: never;
       header?: never;
@@ -706,7 +708,7 @@ export interface operations {
       };
     };
   };
-  koulutusUpdateKoulutus: {
+  koulutusKokonaisuusUpdateKoulutus: {
     parameters: {
       query?: never;
       header?: never;
@@ -730,7 +732,7 @@ export interface operations {
       };
     };
   };
-  koulutusDelete: {
+  koulutusKokonaisuusDeleteKoulutus: {
     parameters: {
       query?: never;
       header?: never;
@@ -750,7 +752,7 @@ export interface operations {
       };
     };
   };
-  koulutusUpdateKategoria: {
+  koulutusKokonaisuusUpdateKategoria: {
     parameters: {
       query?: never;
       header?: never;
@@ -979,7 +981,7 @@ export interface operations {
     parameters: {
       query?: {
         tyyppi?: 'TOIMENKUVA' | 'KOULUTUS' | 'PATEVYYS';
-        id?: string;
+        lahdeId?: string;
       };
       header?: never;
       path?: never;
@@ -1263,7 +1265,7 @@ export interface operations {
       };
     };
   };
-  koulutusGetKategoriat: {
+  koulutusKokonaisuusGetKategoriat: {
     parameters: {
       query?: never;
       header?: never;
@@ -1352,6 +1354,26 @@ export interface operations {
       path: {
         id: string;
       };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  koulutusKokonaisuusDeleteKoulutukset: {
+    parameters: {
+      query: {
+        ids: string[];
+      };
+      header?: never;
+      path?: never;
       cookie?: never;
     };
     requestBody?: never;

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -30,6 +30,60 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/profiili/koulutukset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get all koulutukset and kategoriat of the user */
+    get: operations['koulutusFind'];
+    /**
+     * Updates a set of Koulutus
+     * @description If an existing Koulutus in a Kategoria is omitted, it will be removed.
+     */
+    put: operations['koulutusUpdate'];
+    /** Creates a set of Koulutus associated with an optional Kategoria, creating the Kategoria if necessary */
+    post: operations['koulutusAdd'];
+    delete: operations['koulutusDeleteAll'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/profiili/koulutukset/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations['koulutusGet'];
+    put: operations['koulutusUpdateKoulutus'];
+    post?: never;
+    delete: operations['koulutusDelete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/profiili/koulutukset/kategoriat/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: operations['koulutusUpdateKategoria'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/yksilo/kuva': {
     parameters: {
       query?: never;
@@ -125,33 +179,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/profiili/koulutukset': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get all koulutukset and kategoriat of the user
-     * @description This endpoint can be used to get all koulutukset and kategoriat of the user.
-     *
-     */
-    get: operations['koulutusFind'];
-    put?: never;
-    /**
-     * Adds a new set of koulutus and its associated kategoria
-     * @description This endpoint can be used to add a new Kategoria and its associated Koulutus.
-     *     If kategoria is not present koulutus will be added without kategoria.
-     *
-     */
-    post: operations['koulutusCreate'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/ehdotus/tyomahdollisuudet': {
     parameters: {
       query?: never;
@@ -216,53 +243,6 @@ export interface paths {
     patch: operations['toimenkuvaUpdate'];
     trace?: never;
   };
-  '/api/profiili/koulutukset/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: operations['koulutusGet'];
-    put?: never;
-    post?: never;
-    /**
-     * Delete the koulutus by id
-     * @description This endpoint can be used to delete the koulutus by id
-     *
-     */
-    delete: operations['koulutusDelete'];
-    options?: never;
-    head?: never;
-    /**
-     * Updates the koulutus by id
-     * @description This endpoint can be used to update Koulutus.
-     *
-     */
-    patch: operations['koulutusUpdateKoulutus'];
-    trace?: never;
-  };
-  '/api/profiili/kategoriat/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * Updates a Kategoria by id
-     * @description This endpoint can be used to update the kagoria by id.
-     *
-     */
-    patch: operations['koulutusUpdateKategoria'];
-    trace?: never;
-  };
   '/api/yksilo': {
     parameters: {
       query?: never;
@@ -315,7 +295,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/profiili/kategoriat': {
+  '/api/profiili/koulutukset/kategoriat': {
     parameters: {
       query?: never;
       header?: never;
@@ -404,7 +384,6 @@ export interface components {
      *       "sv": "på svenska"
      *     } */
     LokalisoituTeksti: {
-      empty?: boolean;
       [key: string]: string | undefined;
     };
     PatevyysDto: {
@@ -422,6 +401,32 @@ export interface components {
       id?: string;
       nimi: components['schemas']['LokalisoituTeksti'];
       patevyydet?: components['schemas']['PatevyysDto'][];
+    };
+    KategoriaDto: {
+      /** Format: uuid */
+      id?: string;
+      nimi?: components['schemas']['LokalisoituTeksti'];
+      kuvaus?: components['schemas']['LokalisoituTeksti'];
+    };
+    KoulutusDto: {
+      /** Format: uuid */
+      id?: string;
+      nimi: components['schemas']['LokalisoituTeksti'];
+      kuvaus?: components['schemas']['LokalisoituTeksti'];
+      /** Format: date */
+      alkuPvm?: string;
+      /** Format: date */
+      loppuPvm?: string;
+      osaamiset?: string[];
+    };
+    KoulutusKategoriaDto: {
+      kategoria?: components['schemas']['KategoriaDto'];
+      koulutukset?: components['schemas']['KoulutusDto'][];
+    };
+    KoulutusUpdateResultDto: {
+      /** Format: uuid */
+      kategoria?: string;
+      koulutukset?: string[];
     };
     IdDtoUUID: {
       /** Format: uuid */
@@ -455,32 +460,6 @@ export interface components {
       osaamiset: string[];
       lahde: components['schemas']['OsaamisenLahdeDto'];
     };
-    KategoriaDto: {
-      /** Format: uuid */
-      id?: string;
-      nimi?: components['schemas']['LokalisoituTeksti'];
-      kuvaus?: components['schemas']['LokalisoituTeksti'];
-    };
-    KoulutusDto: {
-      /** Format: uuid */
-      id?: string;
-      nimi: components['schemas']['LokalisoituTeksti'];
-      kuvaus?: components['schemas']['LokalisoituTeksti'];
-      /** Format: date */
-      alkuPvm?: string;
-      /** Format: date */
-      loppuPvm?: string;
-      osaamiset?: string[];
-    };
-    KoulutusKategoriaDto: {
-      kategoria?: components['schemas']['KategoriaDto'];
-      koulutukset?: components['schemas']['KoulutusDto'][];
-    };
-    KoulutusUpdateResultDto: {
-      /** Format: uuid */
-      kategoria?: string;
-      koulutukset?: string[];
-    };
     Taidot: {
       kuvaus: string;
     };
@@ -500,13 +479,10 @@ export interface components {
     };
     YksiloCsrfDto: {
       /** Format: uuid */
-      id: string;
-      /** Format: uuid */
       kuva?: string;
       csrf: components['schemas']['CsrfTokenDto'];
     };
     SivuDtoTyomahdollisuusDto: {
-      sisalto?: components['schemas']['TyomahdollisuusDto'][];
       /**
        * Format: int64
        * @example 10
@@ -517,6 +493,7 @@ export interface components {
        * @example 1
        */
       sivuja?: number;
+      sisalto?: components['schemas']['TyomahdollisuusDto'][];
     };
     TyomahdollisuusDto: {
       /** Format: uuid */
@@ -560,9 +537,9 @@ export interface components {
       lahde?: components['schemas']['OsaamisenLahdeDto'];
     };
     CsrfToken: {
-      parameterName?: string;
       token?: string;
       headerName?: string;
+      parameterName?: string;
     };
   };
   responses: never;
@@ -612,6 +589,184 @@ export interface operations {
     responses: {
       /** @description No Content */
       204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  koulutusFind: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['KoulutusKategoriaDto'][];
+        };
+      };
+    };
+  };
+  koulutusUpdate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['KoulutusKategoriaDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['KoulutusUpdateResultDto'];
+        };
+      };
+    };
+  };
+  koulutusAdd: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['KoulutusKategoriaDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['KoulutusUpdateResultDto'];
+        };
+      };
+    };
+  };
+  koulutusDeleteAll: {
+    parameters: {
+      query: {
+        ids: string[];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  koulutusGet: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['KoulutusDto'];
+        };
+      };
+    };
+  };
+  koulutusUpdateKoulutus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['KoulutusDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  koulutusDelete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  koulutusUpdateKategoria: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['KategoriaDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
         headers: {
           [name: string]: unknown;
         };
@@ -887,50 +1042,6 @@ export interface operations {
       };
     };
   };
-  koulutusFind: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['KoulutusKategoriaDto'][];
-        };
-      };
-    };
-  };
-  koulutusCreate: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['KoulutusKategoriaDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['KoulutusUpdateResultDto'];
-        };
-      };
-    };
-  };
   tyomahdollisuudetCreateEhdotus: {
     parameters: {
       query?: never;
@@ -1066,100 +1177,6 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
-      };
-    };
-  };
-  koulutusGet: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['KoulutusKategoriaDto'];
-        };
-      };
-    };
-  };
-  koulutusDelete: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description No Content */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  koulutusUpdateKoulutus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['KoulutusDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['KoulutusUpdateResultDto'];
-        };
-      };
-    };
-  };
-  koulutusUpdateKategoria: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['KategoriaDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['KoulutusUpdateResultDto'];
-        };
       };
     };
   };
@@ -1303,7 +1320,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': string[];
+          'application/json': string;
         };
       };
     };

--- a/src/routes/Profile/Competences/loader.ts
+++ b/src/routes/Profile/Competences/loader.ts
@@ -12,7 +12,7 @@ export interface CompetencesLoaderData {
 export default (async ({ request }) => {
   const { data: osaamiset } = await client.GET('/api/profiili/osaamiset', { signal: request.signal });
   const { data: tyopaikat } = await client.GET('/api/profiili/tyopaikat', { signal: request.signal });
-  const { data: koulut } = await client.GET('/api/profiili/koulutukset', { signal: request.signal });
+  const { data: koulut } = await client.GET('/api/profiili/koulutuskokonaisuudet', { signal: request.signal });
   const { data: vapaaAjanToiminnot } = await client.GET('/api/profiili/vapaa-ajan-toiminnot', {
     signal: request.signal,
   });

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -47,7 +47,7 @@ const EducationHistory = () => {
       })
       .flat();
 
-    await client.DELETE('/api/profiili/koulutukset', {
+    await client.DELETE('/api/profiili/koulutuskokonaisuudet/koulutukset', {
       headers: {
         [csrf.headerName]: csrf.token,
       },

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -39,22 +39,21 @@ const EducationHistory = () => {
   }, [koulutukset]);
 
   const deleteKoulutukset = async () => {
-    await Promise.all(
-      checkedRows
-        .map((row) => row.key)
-        .map((id) => {
-          const koulutus = koulutukset.filter((row) => row.kategoria).find((row) => row.kategoria?.id === id);
-          return (koulutus?.koulutukset.map((koulutus) => koulutus.id as unknown as string) ?? [id]).map((id) =>
-            client.DELETE('/api/profiili/koulutukset/{id}', {
-              headers: {
-                [csrf.headerName]: csrf.token,
-              },
-              params: { path: { id } },
-            }),
-          );
-        })
-        .flat(),
-    );
+    const ids = checkedRows
+      .map((row) => row.key)
+      .map((id) => {
+        const koulutus = koulutukset.filter((row) => row.kategoria).find((row) => row.kategoria?.id === id);
+        return koulutus?.koulutukset.map((koulutus) => koulutus.id as unknown as string) ?? [id];
+      })
+      .flat();
+
+    await client.DELETE('/api/profiili/koulutukset', {
+      headers: {
+        [csrf.headerName]: csrf.token,
+      },
+      params: { query: { ids } },
+    });
+
     navigate('.', { replace: true });
   };
 

--- a/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
@@ -63,7 +63,7 @@ const EducationHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: EducationHis
       if (selectedRow?.key) {
         const [osaamiset, koulutukset] = await Promise.all([
           client.GET('/api/profiili/osaamiset'),
-          client.GET('/api/profiili/koulutukset'),
+          client.GET('/api/profiili/koulutuskokonaisuudet'),
         ]);
         const koulutus =
           koulutukset.data?.find((koulutus) => koulutus.kategoria?.id === selectedRow.key) ??
@@ -140,9 +140,9 @@ const EducationHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: EducationHis
       },
     };
     if (selectedRow?.key) {
-      await client.PUT('/api/profiili/koulutukset', params);
+      await client.PUT('/api/profiili/koulutuskokonaisuudet', params);
     } else {
-      await client.POST('/api/profiili/koulutukset', params);
+      await client.POST('/api/profiili/koulutuskokonaisuudet', params);
     }
     setIsOpen(false);
     navigate('.', { replace: true });

--- a/src/routes/Profile/EducationHistory/loader.ts
+++ b/src/routes/Profile/EducationHistory/loader.ts
@@ -2,6 +2,6 @@ import { client } from '@/api/client';
 import { LoaderFunction } from 'react-router-dom';
 
 export default (async ({ request }) => {
-  const { data } = await client.GET('/api/profiili/koulutukset', { signal: request.signal });
+  const { data } = await client.GET('/api/profiili/koulutuskokonaisuudet', { signal: request.signal });
   return data;
 }) satisfies LoaderFunction;

--- a/src/routes/Profile/EducationHistory/utils.ts
+++ b/src/routes/Profile/EducationHistory/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/cognitive-complexity */
 import { type SelectableTableRow } from '@/components';
 
 export interface Tutkinto {
@@ -36,30 +35,18 @@ export const getEducationHistoryTableRows = (data: Koulutus[]): SelectableTableR
         loppuPvm: loppuPvm === 0 ? undefined : new Date(loppuPvm),
         osaamisetCount: koulutukset.reduce((acc, cur) => acc + (cur.osaamiset.length ?? 0), 0),
       });
-      koulutukset
-        .sort((a, b) => a.alkuPvm.localeCompare(b.alkuPvm))
-        .forEach((toimenkuva) => {
-          rows.push({
-            key: toimenkuva.id ?? crypto.randomUUID(),
-            nimi: toimenkuva.nimi,
-            alkuPvm: new Date(toimenkuva.alkuPvm),
-            loppuPvm: toimenkuva.loppuPvm ? new Date(toimenkuva.loppuPvm) : undefined,
-            osaamisetCount: toimenkuva.osaamiset.length ?? 0,
-          });
-        });
-    } else {
-      koulutukset
-        .sort((a, b) => a.alkuPvm.localeCompare(b.alkuPvm))
-        .forEach((toimenkuva) => {
-          rows.push({
-            key: toimenkuva.id ?? crypto.randomUUID(),
-            checked: false,
-            nimi: toimenkuva.nimi,
-            alkuPvm: new Date(toimenkuva.alkuPvm),
-            loppuPvm: toimenkuva.loppuPvm ? new Date(toimenkuva.loppuPvm) : undefined,
-            osaamisetCount: toimenkuva.osaamiset.length ?? 0,
-          });
-        });
     }
+    koulutukset
+      .sort((a, b) => a.alkuPvm.localeCompare(b.alkuPvm))
+      .forEach((toimenkuva) => {
+        rows.push({
+          key: toimenkuva.id ?? crypto.randomUUID(),
+          checked: kategoria ? undefined : false,
+          nimi: toimenkuva.nimi,
+          alkuPvm: new Date(toimenkuva.alkuPvm),
+          loppuPvm: toimenkuva.loppuPvm ? new Date(toimenkuva.loppuPvm) : undefined,
+          osaamisetCount: toimenkuva.osaamiset.length ?? 0,
+        });
+      });
     return rows;
   }, []);

--- a/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
@@ -36,9 +36,11 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
     resolver: zodResolver(
       z
         .object({
+          id: z.string().optional(),
           nimi: z.string().min(1),
           toimenkuvat: z
             .object({
+              id: z.string().optional(),
               nimi: z.string().min(1),
               alkuPvm: z.string().date(),
               loppuPvm: z.string().date().optional().or(z.literal('')),
@@ -131,20 +133,19 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
           [csrf.headerName]: csrf.token,
         },
         body: {
-          id: methods.watch('id'),
+          id: data.id,
           nimi: {
             [language]: data.nimi,
           },
-          // TODO: Implement toimenkuvat in the backend
-          // toimenkuvat: data.toimenkuvat.map((toimenkuva, index) => ({
-          //   id: methods.watch(`toimenkuvat.${index}.id`),
-          //   nimi: {
-          //     [language]: toimenkuva.nimi,
-          //   },
-          //   alkuPvm: toimenkuva.alkuPvm,
-          //   loppuPvm: toimenkuva.loppuPvm,
-          //   osaamiset: toimenkuva.osaamiset.map((osaaminen) => osaaminen.id),
-          // })),
+          toimenkuvat: data.toimenkuvat.map((toimenkuva) => ({
+            id: toimenkuva.id,
+            nimi: {
+              [language]: toimenkuva.nimi,
+            },
+            alkuPvm: toimenkuva.alkuPvm,
+            loppuPvm: toimenkuva.loppuPvm,
+            osaamiset: toimenkuva.osaamiset.map((osaaminen) => osaaminen.id),
+          })),
         },
       });
     } else {


### PR DESCRIPTION
## Description
Adds missing update functionality to Tyopaikka. Partially fixes Koulutus (deleting one Koulutus from a Kategoria or adding a new Koulutus to an existing Kategoria is not implemented although the backend API supports that now).

Requires https://github.com/Opetushallitus/jod-yksilo/pull/44

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-538
