### PR TITLE
OPHJOD-577: Create openapi-fetch middlewares for setting csrf token a…

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,27 @@
-import createClient from 'openapi-fetch';
+import { store } from '@/state/store';
+import createClient, { Middleware } from 'openapi-fetch';
 import type { paths } from './schema';
 
 export const client = createClient<paths>();
+
+const csrfMiddleware: Middleware = {
+  onRequest(request) {
+    const state = store.getState();
+    const { csrf } = state.root;
+    if (csrf?.headerName && csrf?.token) {
+      request.headers.set(csrf.headerName, csrf.token);
+    }
+    return request;
+  },
+};
+
+const contentTypeMiddleware: Middleware = {
+  onRequest(request) {
+    if (['PUT', 'POST', 'PATCH'].includes(request.method) && !request.headers.get('Content-Type')) {
+      request.headers.set('Content-Type', 'application/json');
+    }
+    return request;
+  },
+};
+
+client.use(csrfMiddleware, contentTypeMiddleware);

--- a/src/components/OsaamisSuosittelija/OsaamisSuosittelija.tsx
+++ b/src/components/OsaamisSuosittelija/OsaamisSuosittelija.tsx
@@ -1,5 +1,4 @@
 import { client } from '@/api/client';
-import { useAuth } from '@/hooks/useAuth';
 import { Tag, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,8 +23,6 @@ interface OsaamisSuosittelijaProps {
 export const OsaamisSuosittelija = ({ description, value = [], onChange }: OsaamisSuosittelijaProps) => {
   const { t } = useTranslation();
   const { sm } = useMediaQueries();
-  const auth = useAuth();
-  const csrf = auth?.csrf;
   const [ehdotetutOsaamiset, setEhdotetutOsaamiset] = React.useState<Osaaminen[]>([]);
   const [filteredEhdotetutOsaamiset, setFilteredEhdotetutOsaamiset] = React.useState<Osaaminen[]>([]);
 
@@ -37,15 +34,7 @@ export const OsaamisSuosittelija = ({ description, value = [], onChange }: Osaam
 
     const fetchCompetences = async (kuvaus: string) => {
       try {
-        const csrfHeaders: Record<string, string> = {};
-        if (csrf) {
-          csrfHeaders[csrf.headerName] = csrf.token;
-        }
         const { data } = (await client.POST('/api/ehdotus/osaamiset', {
-          headers: {
-            'Content-Type': 'application/json',
-            ...csrfHeaders,
-          },
           body: { kuvaus },
           signal: abortController.current?.signal,
         })) as { data: Osaaminen[] };
@@ -64,7 +53,7 @@ export const OsaamisSuosittelija = ({ description, value = [], onChange }: Osaam
     } else {
       setEhdotetutOsaamiset([]);
     }
-  }, [description, csrf]);
+  }, [description]);
 
   React.useEffect(() => {
     setFilteredEhdotetutOsaamiset([

--- a/src/routes/Profile/Competences/Competences.tsx
+++ b/src/routes/Profile/Competences/Competences.tsx
@@ -7,7 +7,6 @@ import {
   type RoutesNavigationListProps,
 } from '@/components';
 import { useActionBar } from '@/hooks/useActionBar';
-import { useAuth } from '@/hooks/useAuth';
 import { GroupByAlphabet } from '@/routes/Profile/Competences/GroupByAlphabet';
 import { GroupBySource } from '@/routes/Profile/Competences/GroupBySource';
 import { CompetencesLoaderData } from '@/routes/Profile/Competences/loader';
@@ -29,8 +28,6 @@ const Competences = () => {
   const [groupBy, setGroupBy] = React.useState<string>(GROUP_BY_SOURCE);
   const navigationRoutes = React.useMemo(() => mapNavigationRoutes(routes), [routes]);
   const actionBar = useActionBar();
-  const auth = useAuth();
-  const csrf = auth!.csrf;
   const locale = i18n.language as 'fi' | 'sv';
   const [selectedFilters, setSelectedFilters] = React.useState<FiltersType>({});
   const [filterKeys, setFilterKeys] = React.useState<(keyof FiltersType)[]>([]);
@@ -80,10 +77,6 @@ const Competences = () => {
   const deleteOsaaminen = async (id: string) => {
     try {
       await client.DELETE('/api/profiili/osaamiset', {
-        headers: {
-          'Content-Type': 'application/json',
-          [csrf.headerName]: csrf.token,
-        },
         params: { query: { ids: [id] } },
       });
 

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -9,7 +9,6 @@ import {
   type RoutesNavigationListProps,
 } from '@/components';
 import { useActionBar } from '@/hooks/useActionBar';
-import { useAuth } from '@/hooks/useAuth';
 import { Button, ConfirmDialog } from '@jod/design-system';
 import React from 'react';
 import { createPortal } from 'react-dom';
@@ -29,9 +28,6 @@ const EducationHistory = () => {
   const actionBar = useActionBar();
   const [isOpen, setIsOpen] = React.useState(false);
   const [rows, setRows] = React.useState<SelectableTableRow[]>(getEducationHistoryTableRows(koulutukset));
-  const auth = useAuth();
-  const csrf = auth!.csrf;
-
   const checkedRows = rows.filter((row) => row.checked);
 
   React.useEffect(() => {
@@ -48,9 +44,6 @@ const EducationHistory = () => {
       .flat();
 
     await client.DELETE('/api/profiili/koulutuskokonaisuudet/koulutukset', {
-      headers: {
-        [csrf.headerName]: csrf.token,
-      },
       params: { query: { ids } },
     });
 

--- a/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity, sonarjs/no-duplicate-string */
 import { client } from '@/api/client';
 import { SelectableTableRow } from '@/components';
-import { useAuth } from '@/hooks/useAuth';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal, WizardProgress, useMediaQueries } from '@jod/design-system';
 import React from 'react';
@@ -26,8 +25,6 @@ const EducationHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: EducationHis
     i18n: { language },
   } = useTranslation();
   const navigate = useNavigate();
-  const auth = useAuth();
-  const csrf = auth!.csrf;
   const { sm } = useMediaQueries();
 
   const formId = React.useId();
@@ -115,10 +112,6 @@ const EducationHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: EducationHis
   });
   const onSubmit: FormSubmitHandler<EducationHistoryForm> = async ({ data }: { data: EducationHistoryForm }) => {
     const params = {
-      headers: {
-        'Content-Type': 'application/json',
-        [csrf.headerName]: csrf.token,
-      },
       body: {
         kategoria: data.nimi
           ? {

--- a/src/routes/Profile/EducationHistory/modals/EditCategoryModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/EditCategoryModal.tsx
@@ -1,5 +1,4 @@
 import { client } from '@/api/client';
-import { useAuth } from '@/hooks/useAuth';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, InputField, Modal } from '@jod/design-system';
 import React from 'react';
@@ -19,9 +18,6 @@ const EditKategoriaModal = ({ isOpen, onClose, kategoriaId }: EditKategoriaModal
     t,
     i18n: { language },
   } = useTranslation();
-
-  const auth = useAuth();
-  const csrf = auth!.csrf;
 
   const formId = React.useId();
   const methods = useForm<KategoriaForm>({
@@ -51,10 +47,6 @@ const EditKategoriaModal = ({ isOpen, onClose, kategoriaId }: EditKategoriaModal
 
   const onSubmit: FormSubmitHandler<KategoriaForm> = async ({ data }: { data: KategoriaForm }) => {
     const params = {
-      headers: {
-        'Content-Type': 'application/json',
-        [csrf.headerName]: csrf.token,
-      },
       body: {
         kategoria: data.nimi
           ? {

--- a/src/routes/Profile/EducationHistory/modals/EditKoulutusModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/EditKoulutusModal.tsx
@@ -1,6 +1,5 @@
 import { client } from '@/api/client';
 import { OsaamisSuosittelija } from '@/components';
-import { useAuth } from '@/hooks/useAuth';
 import { useDebounceState } from '@/hooks/useDebounceState';
 import { type KoulutusForm } from '@/routes/Profile/EducationHistory/EducationHistoryWizard/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -97,9 +96,6 @@ const EditKoulutusModal = ({ isOpen, onClose, koulutusId }: EditKoulutusModalPro
 
   const deleteKoulutukset = async () => {
     await client.DELETE(API_PATH, {
-      headers: {
-        [csrf.headerName]: csrf.token,
-      },
       params: { path: { id: koulutusId } },
     });
 
@@ -114,8 +110,6 @@ const EditKoulutusModal = ({ isOpen, onClose, koulutusId }: EditKoulutusModalPro
     onClose();
   }
 
-  const auth = useAuth();
-  const csrf = auth!.csrf;
   const formId = React.useId();
   const [step, setStep] = React.useState(0);
   const steps = [MainStep, OsaaminenStep];
@@ -177,10 +171,6 @@ const EditKoulutusModal = ({ isOpen, onClose, koulutusId }: EditKoulutusModalPro
 
   const onSubmit: FormSubmitHandler<KoulutusForm> = async ({ data }: { data: KoulutusForm }) => {
     const params = {
-      headers: {
-        'Content-Type': 'application/json',
-        [csrf.headerName]: csrf.token,
-      },
       params: {
         path: {
           id: data.id!,

--- a/src/routes/Profile/FreeTimeActivities/FreeTimeActivities.tsx
+++ b/src/routes/Profile/FreeTimeActivities/FreeTimeActivities.tsx
@@ -8,7 +8,6 @@ import {
   type RoutesNavigationListProps,
 } from '@/components';
 import { useActionBar } from '@/hooks/useActionBar';
-import { useAuth } from '@/hooks/useAuth';
 import { Button, ConfirmDialog } from '@jod/design-system';
 import React from 'react';
 import { createPortal } from 'react-dom';
@@ -28,9 +27,6 @@ const FreeTimeActivities = () => {
   const actionBar = useActionBar();
   const [isOpen, setIsOpen] = React.useState(false);
   const [rows, setRows] = React.useState(getFreeTimeActivitiesTableRows(vapaaAjanToiminnat));
-  const auth = useAuth();
-  const csrf = auth!.csrf;
-
   const checkedRows = rows.filter((row) => row.checked);
 
   React.useEffect(() => {
@@ -40,9 +36,6 @@ const FreeTimeActivities = () => {
   const deleteVapaaAjanToiminnat = async () => {
     await Promise.all([
       client.DELETE('/api/profiili/vapaa-ajan-toiminnot', {
-        headers: {
-          [csrf.headerName]: csrf.token,
-        },
         params: { query: { ids: checkedRows.map((row) => row.key) } },
       }),
     ]);

--- a/src/routes/Profile/FreeTimeActivities/FreeTimeActivitiesWizard/FreeTimeActivitiesWizard.tsx
+++ b/src/routes/Profile/FreeTimeActivities/FreeTimeActivitiesWizard/FreeTimeActivitiesWizard.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { client } from '@/api/client';
 import { SelectableTableRow } from '@/components';
-import { useAuth } from '@/hooks/useAuth';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal, WizardProgress, useMediaQueries } from '@jod/design-system';
 import React from 'react';
@@ -26,8 +25,6 @@ const FreeTimeActivitiesWizard = ({ isOpen, setIsOpen, selectedRow }: FreeTimeAc
     i18n: { language },
   } = useTranslation();
   const navigate = useNavigate();
-  const auth = useAuth();
-  const csrf = auth!.csrf;
   const { sm } = useMediaQueries();
 
   const formId = React.useId();
@@ -60,16 +57,9 @@ const FreeTimeActivitiesWizard = ({ isOpen, setIsOpen, selectedRow }: FreeTimeAc
       // Fetch osaamiset and patevyydet if the nimi is defined
       if (selectedRow?.key) {
         const [osaamiset, patevyydet] = await Promise.all([
-          client.GET('/api/profiili/osaamiset', {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }),
+          client.GET('/api/profiili/osaamiset'),
           client.GET('/api/profiili/vapaa-ajan-toiminnot/{id}', {
             params: { path: { id: selectedRow.key } },
-            headers: {
-              'Content-Type': 'application/json',
-            },
           }),
         ]);
         return {
@@ -122,10 +112,6 @@ const FreeTimeActivitiesWizard = ({ isOpen, setIsOpen, selectedRow }: FreeTimeAc
     if (selectedRow?.key) {
       await client.PUT('/api/profiili/vapaa-ajan-toiminnot/{id}', {
         params: { path: { id: selectedRow.key } },
-        headers: {
-          'Content-Type': 'application/json',
-          [csrf.headerName]: csrf.token,
-        },
         body: {
           id: methods.watch('id'),
           nimi: {
@@ -144,10 +130,6 @@ const FreeTimeActivitiesWizard = ({ isOpen, setIsOpen, selectedRow }: FreeTimeAc
       });
     } else {
       await client.POST('/api/profiili/vapaa-ajan-toiminnot', {
-        headers: {
-          'Content-Type': 'application/json',
-          [csrf.headerName]: csrf.token,
-        },
         body: {
           nimi: {
             [language]: data.nimi,

--- a/src/routes/Profile/Preferences/Preferences.tsx
+++ b/src/routes/Profile/Preferences/Preferences.tsx
@@ -35,14 +35,13 @@ const Preferences = () => {
   const navigate = useNavigate();
   const auth = useAuth();
   const kuva = auth?.kuva;
-  const csrf = auth!.csrf;
 
   const saveAvatar = async (file: File, hideDialog: () => void) => {
     const formData = new FormData();
     formData.append('file', file);
     await client.POST('/api/yksilo/kuva', {
       headers: {
-        [csrf.headerName]: csrf.token,
+        'Content-Type': 'multipart/form-data',
       },
       body: {
         file: file as unknown as string,
@@ -60,20 +59,12 @@ const Preferences = () => {
   };
 
   const deleteImage = async () => {
-    await client.DELETE('/api/yksilo/kuva', {
-      headers: {
-        [csrf.headerName]: csrf.token,
-      },
-    });
+    await client.DELETE('/api/yksilo/kuva');
     navigate('.', { replace: true });
   };
 
   const deleteAccount = async () => {
-    await client.DELETE('/api/yksilo', {
-      headers: {
-        [csrf.headerName]: csrf.token,
-      },
-    });
+    await client.DELETE('/api/yksilo');
     window.location.href = '/';
   };
 

--- a/src/routes/Profile/WorkHistory/WorkHistory.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistory.tsx
@@ -8,7 +8,6 @@ import {
   type RoutesNavigationListProps,
 } from '@/components';
 import { useActionBar } from '@/hooks/useActionBar';
-import { useAuth } from '@/hooks/useAuth';
 import { Button, ConfirmDialog } from '@jod/design-system';
 import React from 'react';
 import { createPortal } from 'react-dom';
@@ -28,8 +27,6 @@ const WorkHistory = () => {
   const actionBar = useActionBar();
   const [isOpen, setIsOpen] = React.useState(false);
   const [rows, setRows] = React.useState(getWorkHistoryTableRows(tyopaikat));
-  const auth = useAuth();
-  const csrf = auth!.csrf;
 
   const checkedRows = rows.filter((row) => row.checked);
 
@@ -43,9 +40,6 @@ const WorkHistory = () => {
         .map((row) => row.key)
         .map((id) =>
           client.DELETE('/api/profiili/tyopaikat/{id}', {
-            headers: {
-              [csrf.headerName]: csrf.token,
-            },
             params: { path: { id } },
           }),
         ),

--- a/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { client } from '@/api/client';
 import { SelectableTableRow } from '@/components';
-import { useAuth } from '@/hooks/useAuth';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal, WizardProgress, useMediaQueries } from '@jod/design-system';
 import React from 'react';
@@ -26,8 +25,6 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
     i18n: { language },
   } = useTranslation();
   const navigate = useNavigate();
-  const auth = useAuth();
-  const csrf = auth!.csrf;
   const { sm } = useMediaQueries();
 
   const formId = React.useId();
@@ -64,16 +61,9 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
       // Fetch osaamiset and toimenkuvat if the tyopaikka is defined
       if (selectedRow?.key) {
         const [osaamiset, toimenkuvat] = await Promise.all([
-          client.GET('/api/profiili/osaamiset', {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }),
+          client.GET('/api/profiili/osaamiset'),
           client.GET('/api/profiili/tyopaikat/{id}/toimenkuvat', {
             params: { path: { id: selectedRow.key } },
-            headers: {
-              'Content-Type': 'application/json',
-            },
           }),
         ]);
         return {
@@ -128,10 +118,6 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
         params: {
           path: { id: selectedRow.key },
         },
-        headers: {
-          'Content-Type': 'application/json',
-          [csrf.headerName]: csrf.token,
-        },
         body: {
           id: data.id,
           nimi: {
@@ -150,10 +136,6 @@ const WorkHistoryWizard = ({ isOpen, setIsOpen, selectedRow }: WorkHistoryWizard
       });
     } else {
       await client.POST('/api/profiili/tyopaikat', {
-        headers: {
-          'Content-Type': 'application/json',
-          [csrf.headerName]: csrf.token,
-        },
         body: {
           nimi: {
             [language]: data.nimi,

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -2,6 +2,8 @@ import { components } from '@/api/schema';
 import { ErrorNote } from '@/features';
 import { ActionBarContext } from '@/hooks/useActionBar';
 import { AuthContext } from '@/hooks/useAuth';
+import { clearCsrfToken } from '@/state/csrf/csrfSlice';
+import { store } from '@/state/store';
 import { Footer, NavigationBar, PopupList, PopupListItem, SkipLink } from '@jod/design-system';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -32,6 +34,7 @@ const Root = () => {
   ];
 
   const logout = () => {
+    store.dispatch(clearCsrfToken());
     window.location.href = '/logout';
   };
 

--- a/src/routes/Root/loader.test.ts
+++ b/src/routes/Root/loader.test.ts
@@ -1,17 +1,24 @@
 import { components } from '@/api/schema';
 import i18n from '@/i18n/config';
+
 import { describe, expect, it, vi } from 'vitest';
 import loader from './loader';
+
+const mockCsrf: components['schemas']['YksiloCsrfDto']['csrf'] = {
+  headerName: 'headerName',
+  parameterName: 'parameterName',
+  token: 'token',
+};
+
+vi.mock('@/api/client', () => ({
+  client: {
+    GET: () => Promise.resolve({ data: { csrf: { ...mockCsrf } } }),
+  },
+}));
 
 describe('loader', () => {
   it('should change the language if it is different from the current language', async () => {
     const spyChangeLanguage = vi.spyOn(i18n, 'changeLanguage');
-    vi.spyOn(global, 'fetch').mockImplementation(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({}),
-      } as Response),
-    );
 
     await loader({
       request: {} as Request,
@@ -37,21 +44,6 @@ describe('loader', () => {
   });
 
   it('should fetch CSRF token if the request is successful', async () => {
-    const mockCsrf: components['schemas']['YksiloCsrfDto']['csrf'] = {
-      headerName: 'headerName',
-      parameterName: 'parameterName',
-      token: 'token',
-    };
-    vi.spyOn(global, 'fetch').mockImplementation(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            csrf: mockCsrf,
-          }),
-      } as Response),
-    );
-
     const result = await loader({
       request: {} as Request,
       params: {

--- a/src/routes/Root/loader.ts
+++ b/src/routes/Root/loader.ts
@@ -1,6 +1,7 @@
-// import { client } from '@/api/client';
-import { components } from '@/api/schema';
+import { client } from '@/api/client';
 import i18n, { fallbackLng, resources } from '@/i18n/config';
+import { setCsrfToken } from '@/state/csrf/csrfSlice';
+import { store } from '@/state/store';
 import { LoaderFunction, redirect } from 'react-router-dom';
 
 export default (async ({ params: { lng }, request }) => {
@@ -15,11 +16,13 @@ export default (async ({ params: { lng }, request }) => {
   }
 
   // Fetch CSRF token
-  const response = await fetch('/api/yksilo', {
+  const { data, error } = await client.GET('/api/yksilo', {
     signal: request.signal,
   });
-  if (response.ok) {
-    return (await response.json()) as components['schemas']['YksiloCsrfDto'];
+
+  if (!error) {
+    store.dispatch(setCsrfToken(data.csrf));
+    return data;
   }
 
   return null;

--- a/src/routes/Tool/Competences.tsx
+++ b/src/routes/Tool/Competences.tsx
@@ -105,11 +105,7 @@ const Competences = () => {
   };
 
   const fetchTyomahdollisuudet = async () => {
-    const response = await client.GET('/api/tyomahdollisuudet', {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    const response = await client.GET('/api/tyomahdollisuudet');
     if (response.data?.sisalto) {
       setTyomahdollisuudet(response.data.sisalto);
     }

--- a/src/state/csrf/csrfSlice.ts
+++ b/src/state/csrf/csrfSlice.ts
@@ -1,0 +1,32 @@
+import { components } from '@/api/schema';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type CSRF = components['schemas']['CsrfTokenDto'];
+
+type CsrfState = Partial<CSRF>;
+
+const initialState: CsrfState = {
+  token: undefined,
+  parameterName: undefined,
+  headerName: undefined,
+};
+
+const csrfSlice = createSlice({
+  name: 'csrf',
+  initialState,
+  reducers: {
+    setCsrfToken(state, action: PayloadAction<CSRF>) {
+      state.token = action.payload.token;
+      state.parameterName = action.payload.parameterName;
+      state.headerName = action.payload.headerName;
+    },
+    clearCsrfToken(state) {
+      state.token = undefined;
+      state.parameterName = undefined;
+      state.headerName = undefined;
+    },
+  },
+});
+
+export const { setCsrfToken, clearCsrfToken } = csrfSlice.actions;
+export default csrfSlice.reducer;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,14 +2,21 @@ import errorNoteReducer from '@/features/errorNote/errorNoteSlice';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE, persistReducer, persistStore } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
+import sessionStorage from 'redux-persist/lib/storage/session';
+import csrfReducer from './csrf/csrfSlice';
 
 const persistConfig = {
   key: 'root',
   storage,
 };
+const csrfPersistConfig = {
+  key: 'csrf',
+  storage: sessionStorage,
+};
 
 const rootReducer = combineReducers({
   errorNote: errorNoteReducer,
+  csrf: persistReducer(csrfPersistConfig, csrfReducer),
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
### OPHJOD-577: Create openapi-fetch middlewares for setting csrf token and content type

## Description
* Created middleware for openapi-fetch that sets csrf token in one place, instead of everywhere the fetch is being used.
* Also created a middleware that adds `Content-Type: application/json` for every GET, POST, PUT and PATCH call where content type hasn't been specified. This cleaned up a lot of code.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-577
