### PR TITLE
OPHJOD-627 & OPHJOD-635: Use RoundButton's small version to open mobile filters

### DIFF
--- a/src/routes/Profile/Competences/GroupByAlphabet.tsx
+++ b/src/routes/Profile/Competences/GroupByAlphabet.tsx
@@ -1,9 +1,15 @@
 import { ConfirmDialog, Tag } from '@jod/design-system';
 import { t } from 'i18next';
 import React from 'react';
-import { GroupByProps, groupByHeaderClasses, osaaminenColorMap } from './constants';
+import { GroupByProps, MobileFilterButton, groupByHeaderClasses, osaaminenColorMap } from './constants';
 
-export const GroupByAlphabet = ({ locale, osaamiset, deleteOsaaminen, isOsaaminenVisible }: GroupByProps) => {
+export const GroupByAlphabet = ({
+  locale,
+  osaamiset,
+  deleteOsaaminen,
+  isOsaaminenVisible,
+  mobileFilterOpenerComponent,
+}: GroupByProps & MobileFilterButton) => {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ';
 
   const letterHasOsaaminen = (letter: string) =>
@@ -23,7 +29,10 @@ export const GroupByAlphabet = ({ locale, osaamiset, deleteOsaaminen, isOsaamine
   );
   return (
     <>
-      <h2 className="mb-6 text-heading-2">Osaamiseni aakkosjärjestyksessä</h2>
+      <div className="flex flex-row justify-between gap-5">
+        <h2 className="my-6 text-heading-2">Osaamiseni aakkosjärjestyksessä</h2>
+        {mobileFilterOpenerComponent}
+      </div>
       {Array.from(alphabet)
         .filter(letterHasOsaaminen)
         .map((letter) => {

--- a/src/routes/Profile/Competences/GroupBySource.tsx
+++ b/src/routes/Profile/Competences/GroupBySource.tsx
@@ -1,7 +1,7 @@
 import { ConfirmDialog, Tag } from '@jod/design-system';
 import { t } from 'i18next';
 import React from 'react';
-import { groupByHeaderClasses, osaaminenColorMap, type GroupByProps } from './constants';
+import { GroupByProps, MobileFilterButton, groupByHeaderClasses, osaaminenColorMap } from './constants';
 
 export const GroupBySource = ({
   filters,
@@ -10,10 +10,15 @@ export const GroupBySource = ({
   osaamiset,
   deleteOsaaminen,
   isOsaaminenVisible,
-}: GroupByProps) => {
+  mobileFilterOpenerComponent,
+}: GroupByProps & MobileFilterButton) => {
   return (
     <>
-      <h2 className="my-6 text-heading-2">Osaamiseni lähteiden mukaan</h2>
+      <div className="flex flex-row justify-between gap-5">
+        <h2 className="my-6 text-heading-2">Osaamiseni lähteiden mukaan</h2>
+        {mobileFilterOpenerComponent}
+      </div>
+
       {filterKeys.map((key) => {
         return (
           Array.isArray(filters[key]) &&

--- a/src/routes/Profile/Competences/constants.ts
+++ b/src/routes/Profile/Competences/constants.ts
@@ -28,3 +28,7 @@ export interface GroupByProps {
   deleteOsaaminen: (id: string) => Promise<void>;
   isOsaaminenVisible: (key: OsaaminenLahdeTyyppi, id: string) => boolean;
 }
+
+export interface MobileFilterButton {
+  mobileFilterOpenerComponent: React.ReactNode;
+}

--- a/src/routes/Tool/Competences.tsx
+++ b/src/routes/Tool/Competences.tsx
@@ -10,6 +10,7 @@ import {
   Modal,
   RadioButton,
   RadioButtonGroup,
+  RoundButton,
   Slider,
   useMediaQueries,
 } from '@jod/design-system';
@@ -57,7 +58,7 @@ const Filters = ({
         title="Järjestele (kaikki)"
         borderEnabled={isMobile}
         addPadding={isMobile}
-        backgroundClassName="bg-bg-gray-2"
+        backgroundClassName={isMobile ? 'bg-bg-gray-2' : 'bg-bg-gray'}
       >
         <RadioButtonGroup value={order} onChange={setOrder} label="Järjestele (kaikki)" hideLabel>
           <RadioButton label="Tuloksen sopivuus" value="a" />
@@ -69,7 +70,7 @@ const Filters = ({
         title="Toimiala (työmahdollisuudet)"
         borderEnabled={isMobile}
         addPadding={isMobile}
-        backgroundClassName="bg-bg-gray-2"
+        backgroundClassName={isMobile ? 'bg-bg-gray-2' : 'bg-bg-gray'}
       >
         <RadioButtonGroup value={industry} onChange={setIndustry} label="Toimiala (työmahdollisuudet)" hideLabel>
           <RadioButton label="Toimiala x" value="x" />
@@ -197,13 +198,14 @@ const Competences = () => {
             <>
               <div className="mb-2 flex flex-row justify-between">
                 <span className="mr-5 text-heading-3 text-black">Tuloslista</span>
-                <button
-                  className="material-symbols-outlined size-24 select-none"
-                  aria-label="Näytä suodattimet"
+                <RoundButton
+                  size="sm"
+                  bgColor="white"
+                  label="Näytä suodattimet"
+                  hideLabel
                   onClick={() => setShowFilters(true)}
-                >
-                  tune
-                </button>
+                  icon="tune"
+                />
 
                 <Modal
                   open={showFilters}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update Tools/Competences to use RoundButton for opening the filters.
- Add Profile/Competences to have RoundButton and show filters in Modal when in mobile

UI changes regarding Modal is to be done in another ticket.

## Screenshots
### Tools/Competences
<img width="400" alt="image" src="https://github.com/user-attachments/assets/617c8f1b-92ed-4e5f-8e25-4b0fc2769c96">

### Profile/Competences
<img width="400" alt="image" src="https://github.com/user-attachments/assets/71ded58d-1cd3-42c7-b8b3-220cea048722">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e64d945a-d4dc-4363-970c-2dc652580abc">




## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-627
https://jira.eduuni.fi/browse/OPHJOD-635
