### PR TITLE
OPHJOD-621: Use route loader instead of client.get in tool

### DIFF
--- a/src/hooks/useLocalizedRoutes/useLocalizedRoutes.tsx
+++ b/src/hooks/useLocalizedRoutes/useLocalizedRoutes.tsx
@@ -21,7 +21,15 @@ import { EducationHistoryV2, loader as educationHistoryLoader } from '@/routes/P
 import { FreeTimeActivities, loader as freeTimeActivitiesLoader } from '@/routes/Profile/FreeTimeActivities';
 import { WorkHistory, loader as workHistoryLoader } from '@/routes/Profile/WorkHistory';
 import { ErrorElement, NoMatch, Root, loader as rootLoader } from '@/routes/Root';
-import { Goals, Instructions, Interests, Restrictions, Tool, Competences as ToolCompetences } from '@/routes/Tool';
+import {
+  Goals,
+  Instructions,
+  Interests,
+  Restrictions,
+  Tool,
+  Competences as ToolCompetences,
+  toolLoader,
+} from '@/routes/Tool';
 import {
   HowDoIGiveFeedback,
   HowDoIUseTheService,
@@ -75,6 +83,7 @@ const useLocalizedRoutes = () => {
           {
             path: i18n.t('slugs.tool.index', { lng }),
             element: <Tool />,
+            loader: toolLoader,
             children: [
               {
                 index: true,

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -1,4 +1,4 @@
-import { client } from '@/api/client';
+import { components } from '@/api/schema';
 import { SimpleNavigationList, Title } from '@/components';
 import { OpportunityCard } from '@/components/OpportunityCard/OpportunityCard';
 import { Button, Modal, RadioButton, RadioButtonGroup, RoundButton, Slider, useMediaQueries } from '@jod/design-system';
@@ -6,7 +6,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GrTarget } from 'react-icons/gr';
 import { MdBlock, MdOutlineInterests, MdOutlineSchool, MdTune } from 'react-icons/md';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, useLoaderData } from 'react-router-dom';
 import MatchedLink from './MatchedLink';
 
 const MenuBookIcon = ({ size }: { size: number }) => (
@@ -83,6 +83,12 @@ const Tool = () => {
   const [professionsCount] = React.useState(534);
   const [educationsCount] = React.useState(1002);
   const [selectedOpportunities, setSelectedOpportunities] = React.useState<string[]>([]);
+
+  const data = useLoaderData() as components['schemas']['SivuDtoTyomahdollisuusDto'];
+
+  React.useEffect(() => {
+    setTyomahdollisuudet(data.sisalto);
+  }, [data.sisalto]);
 
   const toggleOpportunity = (id: string) => {
     if (selectedOpportunities.includes(id)) {
@@ -162,20 +168,6 @@ const Tool = () => {
       </div>
     );
   };
-
-  const fetchTyomahdollisuudet = async () => {
-    const response = await client.GET('/api/tyomahdollisuudet');
-    if (response.data?.sisalto) {
-      setTyomahdollisuudet(response.data.sisalto);
-    }
-  };
-
-  React.useEffect(() => {
-    const getTyomahdollisuudet = async () => {
-      await fetchTyomahdollisuudet();
-    };
-    void getTyomahdollisuudet();
-  }, []);
 
   return (
     <main role="main" className="mx-auto max-w-[1140px] p-5" id="jod-main">

--- a/src/routes/Tool/index.ts
+++ b/src/routes/Tool/index.ts
@@ -4,5 +4,6 @@ import Instructions from './Instructions';
 import Interests from './Interests';
 import Restrictions from './Restrictions';
 import Tool from './Tool';
+import loader from './loader';
 
-export { Competences, Goals, Instructions, Interests, Restrictions, Tool };
+export { Competences, Goals, Instructions, Interests, Restrictions, Tool, loader as toolLoader };

--- a/src/routes/Tool/loader.ts
+++ b/src/routes/Tool/loader.ts
@@ -1,0 +1,8 @@
+import { client } from '@/api/client';
+import { LoaderFunction } from 'react-router-dom';
+
+export default (async ({ request }) => {
+  const { data } = await client.GET('/api/tyomahdollisuudet', { signal: request.signal });
+
+  return data;
+}) satisfies LoaderFunction;


### PR DESCRIPTION
## Description
* In order to have stadardized way of fethcing data, a router loader is used to fetch "työmahdollisuudet" in Tool section. Now there are no manual "client.get" calls for routes.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-621
