### PR TITLE
OPHJOD-703: Add a button in tool for updating opportunities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,8 +1665,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#139cfd1244bc1c7a972608a6d79105f97be20a55",
-      "license": "EUPL-1.2",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#d26ae5c482dccbecbed8a3a990af573e8c973c89",
       "dependencies": {
         "@ark-ui/react": "^3.0.0-1",
         "@floating-ui/react": "^0.26.12",

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -18,6 +18,8 @@
   "edit": "Muokkaa",
   "no-competences": "Ei osaamisia",
   "count-competences": "{{count}} osaamista",
+  "proposed-competences": "Ehdotetut osaamiset",
+  "competences-of-your-choice": "Valitsemasi osaamiset",
   "education-history": {
     "add-new-degree": "Lisää uusi tutkinto",
     "add-new-education": "Lisää uusi koulutus",
@@ -235,10 +237,11 @@
   "started": "Alkoi",
   "terms-of-service": "Käyttöehdot",
   "tool": {
+    "update-job-opportunities-list": "Päivitä mahdollisuuslista",
     "competences": {
+      "opportunities-title": "Mahdollisuutesi",
       "adjust-data-emphasis": "Säädä syöttämäsi tietojen painotuksia - tulokset päivittyvät samanaikaisesti uusien painotusten mukaan.",
-      "available-options": "Lukumääräisesti valittavissasi eri vaihtoehtoja",
-      "available-options-totals": "{{professionsCount}} ammattia, {{educationsCount}} koulutusta.",
+      "available-options-totals": "Syöttämilläsi tiedoilla sinulle löytyy {{professionsCount}} ammattia ja {{educationsCount}} koulutusmahdollisuutta.",
       "common-educational-background": "Yleisin koulutustausta",
       "employment-outlook": "Työllisyysnäkymä",
       "field-description": "Kirjoita taitosi tekstikenttään. Lisää osaaminen klikkaamalla ‘+‘-merkkiä osaamisen vieressä. Poista osaaminen klikkaamalla rastia.",
@@ -289,7 +292,6 @@
     "add-new-job-description": "Lisää uusi toimenkuva",
     "add-new-workplace": "Lisää uusi työpaikka",
     "competences": "Osaamiset",
-    "competences-of-your-choice": "Valitsemasi osaamiset",
     "confirm-delete-job-description": "Haluatko varmasti poistaa toimenkuvan?",
     "confirm-delete-work-history": "Haluatko varmasti poistaa työpaikan?",
     "count-competences": "{{count}} osaamista",
@@ -302,7 +304,6 @@
     "identify-competences": "Tunnista osaamisia",
     "job-description": "Toimenkuva",
     "job-duties": "Työtehtävät",
-    "proposed-competences": "Ehdotetut osaamiset",
     "summary": "Yhteenveto",
     "workplace-or-job-description": "Työpaikka / toimenkuva"
   }

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -164,39 +164,33 @@ const Tool = () => {
       setTyomahdollisuudet(sortedResults);
     };
 
-    void fetchOpportunities();
+    if (Object.keys(tyomahdollisuusEhdotukset ?? {}).length > 0) {
+      void fetchOpportunities();
+    }
   }, [tyomahdollisuusEhdotukset]);
 
-  React.useEffect(() => {
+  const [ehdotuksetLoading, setEhdotuksetLoading] = React.useState(false);
+  const updateEhdotukset = async () => {
     abortController.current?.abort('Abort previous request');
     abortController.current = new AbortController();
 
-    const fetchSuggestions = async () => {
-      const { data } = await client.POST('/api/ehdotus/tyomahdollisuudet', {
-        body: {
-          osaamiset: selectedCompetences.map((item) => item.id),
-          kiinnostukset: selectedInterests.map((item) => item.id),
-          osaamisPainotus: competencesMultiplier / 100,
-          kiinnostusPainotus: interestMultiplier / 100,
-          rajoitePainotus: restrictionsMultiplier / 100,
-        },
-        signal: abortController.current?.signal,
-      });
+    setEhdotuksetLoading(true);
+    const { data } = await client.POST('/api/ehdotus/tyomahdollisuudet', {
+      body: {
+        osaamiset: selectedCompetences.map((item) => item.id),
+        kiinnostukset: selectedInterests.map((item) => item.id),
+        osaamisPainotus: competencesMultiplier / 100,
+        kiinnostusPainotus: interestMultiplier / 100,
+        rajoitePainotus: restrictionsMultiplier / 100,
+      },
+      signal: abortController.current?.signal,
+    });
 
-      if (data) {
-        setTyomahdollisuusEhdotukset(ehdotusDataToRecord(data as EhdotusData[]));
-      }
-    };
-
-    // Debounce the fetch
-    const timer = setTimeout(() => {
-      void fetchSuggestions();
-    }, 300);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [selectedCompetences, selectedInterests, competencesMultiplier, interestMultiplier, restrictionsMultiplier]);
+    if (data) {
+      setTyomahdollisuusEhdotukset(ehdotusDataToRecord(data as EhdotusData[]));
+    }
+    setEhdotuksetLoading(false);
+  };
 
   const toggleOpportunity = (id: string) => {
     if (selectedOpportunities.includes(id)) {
@@ -290,20 +284,27 @@ const Tool = () => {
         }
       />
 
+      <div className="mb-8 mt-5">
+        <Button
+          onClick={() => void updateEhdotukset()}
+          label={t('tool.update-job-opportunities-list')}
+          variant="accent"
+          disabled={ehdotuksetLoading}
+        />
+      </div>
+
       <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-3">
         <div className="col-span-1 sm:col-span-3">
-          <div className="mt-10 flex flex-col sm:mt-11 sm:flex-row">
-            <span className="text-body-md font-arial text-black font-medium sm:text-body-lg sm:font-poppins">
-              {t('tool.competences.available-options')}{' '}
-              <span className="text-heading-3 font-bold">
-                {t('tool.competences.available-options-totals', { professionsCount, educationsCount })}
-              </span>
+          <div className="flex flex-col sm:flex-row">
+            <span className="text-body-md text-black font-medium sm:text-body-lg">
+              <h2 className="text-heading-2 mb-4">{t('tool.competences.opportunities-title')}</h2>
+              {t('tool.competences.available-options-totals', { professionsCount, educationsCount })}
             </span>
           </div>
         </div>
 
-        <div className="col-span-1 mt-10 flex flex-col sm:col-span-3 sm:mt-9 sm:flex-row">
-          <span className="text-body-md font-arial text-black font-medium sm:text-body-lg sm:font-poppins">
+        <div className="col-span-1 mt-5 flex flex-col sm:col-span-3 sm:flex-row">
+          <span className="text-body-md text-black font-medium sm:text-body-lg">
             {t('tool.competences.adjust-data-emphasis')}
           </span>
         </div>


### PR DESCRIPTION
## Description

* Added a button for refreshing job opportunity suggestions instead of automation
* Button is disabled during fetching
* Updated to latest design system in order to use the accent variant of Button component
* Some minor translation and styling updates to the text between the new button and sliders, check the screenshot

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-703

![image](https://github.com/user-attachments/assets/0a6b5da9-4013-4bff-ad64-f7e2f56efb1e)

Translation/styling changes:
![image](https://github.com/user-attachments/assets/ca25bcf0-4b53-49fe-b9f4-0a6942ac8b16)


