### PR TITLE
OPHJOD-800: Fix issue with Slider on narrow screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1666,7 +1666,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#22bdacad59d7182d0b300f67362132af9bacee5f",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#b6e30911057b2edf4123c6c387571676d83ecd12",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^3.0.0-1",

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -226,7 +226,7 @@ const Tool = () => {
           </span>
         </div>
 
-        <div className="col-span-1 mt-6 grid grid-cols-1 gap-7 sm:col-span-3 sm:mt-5 sm:grid-cols-3">
+        <div className="col-span-1 mt-6 gap-7 sm:col-span-3 sm:mt-5 flex flex-col sm:flex-row flex-wrap">
           <Slider
             label={t('competences')}
             rightLabel={t('interests')}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Fix the issue with the Slider in narrow screens

These changes should have been in the earlier Slider use PR but I managed to get them lost somehow.

## Screenshots

### Desktop
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b56cedad-0087-4357-9999-a6631ee9453a">

### Desktop, narrow and therefore wrapped
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7e71931e-1766-4433-8fe7-f97fffbf29cc">


### Mobile
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8aff98e5-fe28-4b70-88f2-d023af5bb80b">



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-800
