### PR TITLE
OPHJOD-706: Fix order of competences by source filter

### DIFF
--- a/src/routes/Profile/Competences/Competences.tsx
+++ b/src/routes/Profile/Competences/Competences.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from 'react-i18next';
 import { MdTune } from 'react-icons/md';
 import { useLoaderData, useOutletContext } from 'react-router-dom';
 import { mapNavigationRoutes } from '../utils';
-import { GROUP_BY_ALPHABET, GROUP_BY_SOURCE, GROUP_BY_THEME, type FiltersType } from './constants';
+import { FILTERS_ORDER, GROUP_BY_ALPHABET, GROUP_BY_SOURCE, GROUP_BY_THEME, type FiltersType } from './constants';
 
 const Competences = () => {
   const routes = useOutletContext<RoutesNavigationListProps['routes']>();
@@ -83,7 +83,11 @@ const Competences = () => {
     if (!initialized) {
       const initialFilters = initFilters(osaamiset);
       setSelectedFilters(initialFilters);
-      setFilterKeys(Object.keys(initialFilters) as (keyof FiltersType)[]);
+      setFilterKeys(
+        [...(Object.keys(initialFilters) as (keyof FiltersType)[])].sort(
+          (a, b) => FILTERS_ORDER.indexOf(a) - FILTERS_ORDER.indexOf(b),
+        ),
+      );
       setInitialized(true);
     }
   }, [initFilters, initialized, osaamiset]);

--- a/src/routes/Profile/Competences/constants.ts
+++ b/src/routes/Profile/Competences/constants.ts
@@ -12,6 +12,7 @@ export interface FilterData {
 }
 
 export type FiltersType = Partial<Record<OsaaminenLahdeTyyppi, FilterData[]>>;
+export const FILTERS_ORDER = ['TOIMENKUVA', 'KOULUTUS', 'PATEVYYS', 'KIINNOSTUS', 'MUU_OSAAMINEN'] as const;
 
 export interface GroupByProps {
   filters: FiltersType;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,7 +12,7 @@ declare interface OsaaminenApiResponse {
     };
   };
   lahde: {
-    tyyppi: 'TOIMENKUVA' | 'KOULUTUS' | 'PATEVYYS';
+    tyyppi: 'TOIMENKUVA' | 'KOULUTUS' | 'PATEVYYS' | 'MUU_OSAAMINEN';
     id: string;
   };
 }


### PR DESCRIPTION
## Description

Fix order of profile competence grouping by source to

1. TOIMENKUVA
2. KOULUTUS
3. PATEVYYS
4. KIINNOSTUS
5. MUU_OSAAMINEN

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-706
