### PR TITLE
OPHJOD-702: Add ProgressIndicatorCard when loading opportunities in Tool

### DIFF
--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Modal,
   Pagination,
+  ProgressIndicatorCard,
   RadioButton,
   RadioButtonGroup,
   RoundButton,
@@ -319,6 +320,7 @@ const Tool = () => {
             </>
           )}
           <div className="flex flex-col gap-5 mb-8">
+            {toolStore.ehdotuksetLoading && <ProgressIndicatorCard />}
             {toolStore.tyomahdollisuudet.map((tyomahdollisuus) => {
               const { id } = tyomahdollisuus;
               const isFavorite = toolStore.suosikit?.find((s) => s.suosionKohdeId === id) !== undefined;


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add `ProgressIndicatorCard` visible when loading opportunities in Tools.

**Waiting for design to decide is the whole progress indicator card needed at all.**

## Screenshot

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6d063273-46f9-4804-a6e3-7e408f08cc80">


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-702
