### PR TITLE
OPHJOD-829: Use pagination with opportunities in tool

### DIFF
--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -173,6 +173,12 @@
     "work": "Työmahdollisuus"
   },
   "osaamispolku": "Osaamispolku",
+  "pagination": {
+    "first": "Siirry ensimmäiselle sivulle",
+    "last": "Siirry viimeiselle sivulle",
+    "next": "Siirry seuraavalle sivulle",
+    "previous": "Siirry edelliselle sivulle"
+  },
   "preferences": {
     "confirm-delete-my-account": "Haluatko varmasti poistaa tilisi?",
     "delete-my-account": "Poista tilini",


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Added pagination to opportunities in tool
* Split fetching ehdotukset and työmahdollisuudet, ehdotukset don't need to be updated on page change
* Scroll to start of the results after page change

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-829

![image](https://github.com/user-attachments/assets/50a9b463-e37f-4206-b4d3-0d43265ba4a5)
