### PR TITLE
OPHJOD-850: Remove unused translations from Pagination component's usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,7 +1667,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#7a6a2c1e4779370deaaace4994585d32f57b3fa6",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#d8c027838717b985f0c4515e9796b5eb35eab116",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^3.0.0-1",

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -174,8 +174,6 @@
   },
   "osaamispolku": "Osaamispolku",
   "pagination": {
-    "first": "Siirry ensimmäiselle sivulle",
-    "last": "Siirry viimeiselle sivulle",
     "next": "Siirry seuraavalle sivulle",
     "previous": "Siirry edelliselle sivulle"
   },

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -355,8 +355,6 @@ const Tool = () => {
             translations={{
               nextTriggerLabel: t('pagination.next'),
               prevTriggerLabel: t('pagination.previous'),
-              lastPageTriggerLabel: t('pagination.last'),
-              firstPageTriggerLabel: t('pagination.first'),
             }}
             totalItems={toolStore.ehdotuksetCount}
             onPageChange={(data) => void onPageChange(data)}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Remove the translations no longer used with Pagination on Tool page
- Update `@jod/design-system`

Related to DS-side PR: Opetushallitus/jod-design-system/pull/159

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-850
