### PR TITLE
OPHJOD-854: Update Profile's sidenav to have indents on Competences

### DIFF
--- a/src/components/MainLayout/RoutesNavigationList.tsx
+++ b/src/components/MainLayout/RoutesNavigationList.tsx
@@ -45,6 +45,7 @@ export const RoutesNavigationList = ({ routes, onClick }: RoutesNavigationListPr
   return (
     <ul className="flex flex-col gap-y-2 py-4">
       {routes.map((route) => {
+        const isSubPage = route.path.split('/').slice(1).length > 1;
         return (
           <li key={route.path} className="flex min-h-7 items-center w-full">
             {route.authRequired && !data ? (
@@ -57,11 +58,14 @@ export const RoutesNavigationList = ({ routes, onClick }: RoutesNavigationListPr
                 replace={route.replace}
                 lang={i18n.language}
                 className={({ isActive }) =>
-                  cx('hyphens-auto text-black w-full pl-5 block py-3 text-button-md hover:underline', {
+                  cx('hyphens-auto text-black w-full block py-3 text-button-md hover:underline', {
                     'bg-secondary-1-50 rounded-md': isActive,
+                    'pl-7': isSubPage,
+                    'pl-5': !isSubPage,
                   })
                 }
                 onClick={onClick}
+                end
               >
                 {route.name}
               </NavLink>

--- a/src/hooks/useAppRoutes/index.ts
+++ b/src/hooks/useAppRoutes/index.ts
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 export const useAppRoutes = () => {
   const { t } = useTranslation();
 
+  const competencesPath = t('slugs.profile.competences');
+
   const profileRoutes = [
     {
       name: t('profile.preferences.title'),
@@ -14,27 +16,27 @@ export const useAppRoutes = () => {
     },
     {
       name: t('profile.competences.title'),
-      path: t('slugs.profile.competences'),
+      path: competencesPath,
+    },
+    {
+      name: t('profile.work-history.title'),
+      path: `${competencesPath}/${t('slugs.profile.work-history')}`,
+    },
+    {
+      name: t('profile.education-history.title'),
+      path: `${competencesPath}/${t('slugs.profile.education-history')}`,
+    },
+    {
+      name: t('profile.free-time-activities.title'),
+      path: `${competencesPath}/${t('slugs.profile.free-time-activities')}`,
+    },
+    {
+      name: t('profile.something-else.title'),
+      path: `${competencesPath}/${t('slugs.profile.something-else')}`,
     },
     {
       name: t('profile.interests.title'),
       path: t('slugs.profile.interests'),
-    },
-    {
-      name: t('profile.work-history.title'),
-      path: t('slugs.profile.work-history'),
-    },
-    {
-      name: t('profile.education-history.title'),
-      path: t('slugs.profile.education-history'),
-    },
-    {
-      name: t('profile.free-time-activities.title'),
-      path: t('slugs.profile.free-time-activities'),
-    },
-    {
-      name: t('profile.something-else.title'),
-      path: t('slugs.profile.something-else'),
     },
   ];
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -45,6 +45,8 @@ import {
   WhoProvidesTheService,
 } from './UserGuide';
 
+const competencesSlug = 'slugs.profile.competences';
+
 const profileRoutes = supportedLanguageCodes.map(
   (lng) =>
     ({
@@ -69,39 +71,39 @@ const profileRoutes = supportedLanguageCodes.map(
         },
         {
           id: `{slugs.profile.competences}|${lng}`,
-          path: i18n.t('slugs.profile.competences', { lng }),
+          path: i18n.t(competencesSlug, { lng }),
           loader: withYksiloContext(competencesLoader),
           element: <ProfileCompetences />,
+        },
+        {
+          id: `{slugs.profile.work-history}|${lng}`,
+          path: `${i18n.t(competencesSlug, { lng })}/${i18n.t('slugs.profile.work-history', { lng })}`,
+          loader: withYksiloContext(workHistoryLoader),
+          element: <WorkHistory />,
+        },
+        {
+          id: `{slugs.profile.education-history}|${lng}`,
+          path: `${i18n.t(competencesSlug, { lng })}/${i18n.t('slugs.profile.education-history', { lng })}`,
+          loader: withYksiloContext(educationHistoryLoader),
+          element: <EducationHistory />,
+        },
+        {
+          id: `{slugs.profile.free-time-activities}|${lng}`,
+          path: `${i18n.t(competencesSlug, { lng })}/${i18n.t('slugs.profile.free-time-activities', { lng })}`,
+          loader: withYksiloContext(freeTimeActivitiesLoader),
+          element: <FreeTimeActivities />,
+        },
+        {
+          id: `{slugs.profile.something-else}|${lng}`,
+          path: `${i18n.t(competencesSlug, { lng })}/${i18n.t('slugs.profile.something-else', { lng })}`,
+          element: <SomethingElse />,
+          loader: withYksiloContext(muuOsaaminenLoader),
         },
         {
           id: `{slugs.profile.interests}|${lng}`,
           path: i18n.t('slugs.profile.interests', { lng }),
           loader: withYksiloContext(interestsLoader),
           element: <ProfileInterests />,
-        },
-        {
-          id: `{slugs.profile.work-history}|${lng}`,
-          path: i18n.t('slugs.profile.work-history', { lng }),
-          loader: withYksiloContext(workHistoryLoader),
-          element: <WorkHistory />,
-        },
-        {
-          id: `{slugs.profile.education-history}|${lng}`,
-          path: i18n.t('slugs.profile.education-history', { lng }),
-          loader: withYksiloContext(educationHistoryLoader),
-          element: <EducationHistory />,
-        },
-        {
-          id: `{slugs.profile.free-time-activities}|${lng}`,
-          path: i18n.t('slugs.profile.free-time-activities', { lng }),
-          loader: withYksiloContext(freeTimeActivitiesLoader),
-          element: <FreeTimeActivities />,
-        },
-        {
-          id: `{slugs.profile.something-else}|${lng}`,
-          path: i18n.t('slugs.profile.something-else', { lng }),
-          element: <SomethingElse />,
-          loader: withYksiloContext(muuOsaaminenLoader),
         },
       ],
     }) as RouteObject,


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Add indent to side nav in Profile + MegaMenu
  - Uses the same component in both places
- Pages that are intend now has the path to them changed; `competences/` added to start

## Screenshots

### profile/competences/work-history
<img width="600" alt="side nav in profile" src="https://github.com/user-attachments/assets/ff954b97-cb16-4d5b-af19-9dae6eb56be3">

### MegaMenu
<img width="600" alt="MegaMenu" src="https://github.com/user-attachments/assets/447ed10b-68f0-4f09-ab67-dce0e4eeb8fc">
 

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-854
