### PR TITLE
OPHJOD-882: Refactor helping tools to be reusable

### DIFF
--- a/src/components/HelpingToolsContent/HelpingToolLinkItem.tsx
+++ b/src/components/HelpingToolsContent/HelpingToolLinkItem.tsx
@@ -1,0 +1,44 @@
+import { ProfileLink } from '@/routes/Profile/utils';
+import React from 'react';
+
+export interface HelpingToolLinkItemProps {
+  icon: React.ReactNode;
+  title: string;
+}
+
+export interface HelpingToolProfileLinkItemProps extends HelpingToolLinkItemProps {
+  profileLink: ProfileLink;
+}
+
+export const HelpingToolProfileLinkItem = ({ profileLink, icon, title }: HelpingToolProfileLinkItemProps) => {
+  return (
+    <HelpingToolLinkItem
+      component={({ ...rootProps }) => (
+        <profileLink.component to={profileLink.to} {...rootProps}></profileLink.component>
+      )}
+      icon={icon}
+      title={title}
+    />
+  );
+};
+
+interface ComponentProp {
+  component: React.ComponentType<{ children: React.ReactNode }>;
+}
+
+export const HelpingToolLinkItem = ({
+  component: Component,
+  icon,
+  title,
+}: HelpingToolLinkItemProps & ComponentProp) => {
+  return (
+    <li className="group">
+      <Component>
+        <div className="flex gap-x-4">
+          {icon}
+          <div className="text-heading-4 text-black group-hover:text-accent group-hover:underline">{title}</div>
+        </div>
+      </Component>
+    </li>
+  );
+};

--- a/src/components/HelpingToolsContent/HelpingToolsContent.tsx
+++ b/src/components/HelpingToolsContent/HelpingToolsContent.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { HelpingToolLinkItemProps, HelpingToolProfileLinkItemProps } from '.';
+
+interface HelpingToolsContentProps {
+  children: (
+    | React.ReactElement<HelpingToolProfileLinkItemProps>
+    | React.ReactElement<HelpingToolLinkItemProps>
+    | React.ReactNode
+  )[];
+  text: string;
+}
+
+export const HelpingToolsContent = ({ children, text }: HelpingToolsContentProps) => {
+  return (
+    <>
+      <span className="text-body-sm sm:text-body-xs">
+        <div>{text}</div>
+      </span>
+      <ul className="flex flex-col gap-4 text-button-md">{children}</ul>
+    </>
+  );
+};

--- a/src/components/HelpingToolsContent/index.ts
+++ b/src/components/HelpingToolsContent/index.ts
@@ -1,0 +1,3 @@
+export { HelpingToolLinkItem, HelpingToolProfileLinkItem } from './HelpingToolLinkItem';
+export type { HelpingToolLinkItemProps, HelpingToolProfileLinkItemProps } from './HelpingToolLinkItem';
+export { HelpingToolsContent } from './HelpingToolsContent';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,6 +1,8 @@
 export { ErrorNote } from './ErrorNote';
 export { ExperienceTable } from './ExperienceTable/ExperienceTable';
 export { type ExperienceTableRowData } from './ExperienceTable/ExperienceTableRow';
+export { HelpingToolLinkItem, HelpingToolProfileLinkItem, HelpingToolsContent } from './HelpingToolsContent';
+export type { HelpingToolLinkItemProps, HelpingToolProfileLinkItemProps } from './HelpingToolsContent';
 export { LanguageButton } from './LanguageButton/LanguageButton';
 export { LanguageMenu } from './LanguageMenu/LanguageMenu';
 export {

--- a/src/routes/Profile/utils.tsx
+++ b/src/routes/Profile/utils.tsx
@@ -1,16 +1,34 @@
 import { components } from '@/api/schema';
 import { type RoutesNavigationListProps } from '@/components';
-import { Link } from 'react-router-dom';
+import { Link, LinkProps } from 'react-router-dom';
 
 export const mapNavigationRoutes = (routes: RoutesNavigationListProps['routes']) =>
   routes.map((route) => ({ ...route, path: `../${route.path}` }));
+
+export type ProfileLink =
+  | {
+      to: string;
+      component: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<HTMLAnchorElement>>;
+    }
+  | {
+      to: string;
+      component: ({
+        to,
+        className,
+        children,
+      }: {
+        to: object | string;
+        className?: string;
+        children: React.ReactNode;
+      }) => JSX.Element;
+    };
 
 export const generateProfileLink = (
   profilePageSlugs: string[],
   data: { etunimi?: string; sukunimi?: string; csrf: components['schemas']['CsrfTokenDto'] } | null,
   language: string,
   t: (key: string) => string,
-) => {
+): ProfileLink => {
   const profilePageSlug = profilePageSlugs.map((slug) => t(slug)).join('/');
 
   if (data) {

--- a/src/routes/Tool/Competences.tsx
+++ b/src/routes/Tool/Competences.tsx
@@ -1,5 +1,5 @@
 import { components } from '@/api/schema';
-import { OsaamisSuosittelija } from '@/components';
+import { HelpingToolProfileLinkItem, HelpingToolsContent, OsaamisSuosittelija } from '@/components';
 import { useDebounceState } from '@/hooks/useDebounceState';
 import { Accordion, InputField, useMediaQueries } from '@jod/design-system';
 import React from 'react';
@@ -10,7 +10,7 @@ import { useOutletContext, useRouteLoaderData } from 'react-router-dom';
 import { generateProfileLink } from '../Profile/utils';
 import { ContextType } from './types';
 
-const HelpingToolsContent = () => {
+const HelpingToolsContents = () => {
   const {
     t,
     i18n: { language },
@@ -37,45 +37,28 @@ const HelpingToolsContent = () => {
   );
 
   return (
-    <>
-      <span className="text-body-sm sm:text-body-xs">
-        <div>{t('profile.help-text')}</div>
-      </span>
-      <ul className="flex flex-col gap-4 text-button-md">
-        <li>
-          <educationLink.component to={educationLink.to}>
-            <div className="flex gap-x-3">
-              <MdOutlineSchool size={24} color="#00818A" />
-              <div>{t('profile.education-history.title')}</div>
-            </div>
-          </educationLink.component>
-        </li>
-        <li>
-          <workLink.component to={workLink.to}>
-            <div className="flex gap-x-3">
-              <TbBriefcase2 size={24} color="#AD4298" />
-              <div>{t('profile.work-history.title')}</div>
-            </div>
-          </workLink.component>
-        </li>
-        <li>
-          <freeTimeLink.component to={freeTimeLink.to}>
-            <div className="flex gap-x-3">
-              <MdOutlineSailing size={24} className="text-accent" />
-              <div>{t('profile.free-time-activities.title')}</div>
-            </div>
-          </freeTimeLink.component>
-        </li>
-        <li>
-          <somethingElseLink.component to={somethingElseLink.to}>
-            <div className="flex gap-x-3">
-              <MdLightbulbOutline size={24} className="text-secondary-5" />
-              <div>{t('profile.something-else.title')}</div>
-            </div>
-          </somethingElseLink.component>
-        </li>
-      </ul>
-    </>
+    <HelpingToolsContent text={t('profile.help-text')}>
+      <HelpingToolProfileLinkItem
+        profileLink={educationLink}
+        icon={<MdOutlineSchool size={24} color="#00818A" />}
+        title={t('profile.education-history.title')}
+      />
+      <HelpingToolProfileLinkItem
+        profileLink={workLink}
+        icon={<TbBriefcase2 size={24} color="#AD4298" />}
+        title={t('profile.work-history.title')}
+      />
+      <HelpingToolProfileLinkItem
+        profileLink={freeTimeLink}
+        icon={<MdOutlineSailing size={24} className="text-accent" />}
+        title={t('profile.free-time-activities.title')}
+      />
+      <HelpingToolProfileLinkItem
+        profileLink={somethingElseLink}
+        icon={<MdLightbulbOutline size={24} className="text-secondary-5" />}
+        title={t('profile.something-else.title')}
+      />
+    </HelpingToolsContent>
   );
 };
 
@@ -118,7 +101,7 @@ const Competences = () => {
           {sm ? (
             <>
               <span className="text-heading-4 text-black">{t('tools')}</span>
-              <HelpingToolsContent />
+              <HelpingToolsContents />
             </>
           ) : (
             <Accordion
@@ -127,7 +110,7 @@ const Competences = () => {
               expandMoreText={t('expand-more')}
               lang={language}
             >
-              <HelpingToolsContent />
+              <HelpingToolsContents />
             </Accordion>
           )}
         </div>

--- a/src/routes/Tool/Interests.tsx
+++ b/src/routes/Tool/Interests.tsx
@@ -1,5 +1,10 @@
 import { components } from '@/api/schema';
-import { OsaamisSuosittelija } from '@/components';
+import {
+  HelpingToolLinkItem,
+  HelpingToolProfileLinkItem,
+  HelpingToolsContent,
+  OsaamisSuosittelija,
+} from '@/components';
 import { useDebounceState } from '@/hooks/useDebounceState';
 import { Accordion, InputField, useMediaQueries } from '@jod/design-system';
 import React from 'react';
@@ -9,7 +14,7 @@ import { useOutletContext, useRouteLoaderData } from 'react-router-dom';
 import { generateProfileLink } from '../Profile/utils';
 import { ContextType } from './types';
 
-const HelpingToolsContent = () => {
+const HelpingToolsContents = () => {
   const {
     t,
     i18n: { language },
@@ -23,33 +28,23 @@ const HelpingToolsContent = () => {
   );
 
   return (
-    <>
-      <span className="text-body-sm sm:text-body-xs">
-        <div>{t('tool.interests.help-text')}</div>
-      </span>
-      <ul className="flex flex-col gap-4 text-button-md">
-        <li>
-          <interestsLink.component to={interestsLink.to}>
-            <div className="flex gap-x-3">
-              <MdOutlineInterests size={24} color="#006DB3" />
-              <div>{t('profile.interests.title')}</div>
-            </div>
-          </interestsLink.component>
-        </li>
-        <li>
-          <div className="flex gap-x-3">
-            <MdOutlineQuiz size={24} color="#006DB3" />
-            <div>{t('tool.interests.riasec-test')}</div>
-          </div>
-        </li>
-        <li>
-          <div className="flex gap-x-3">
-            <MdOutlineInterests size={24} color="#AD4298" />
-            <div>{t('tool.interests.interest-barometer')}</div>
-          </div>
-        </li>
-      </ul>
-    </>
+    <HelpingToolsContent text={t('tool.interests.help-text')}>
+      <HelpingToolProfileLinkItem
+        profileLink={interestsLink}
+        icon={<MdOutlineInterests size={24} color="#006DB3" />}
+        title={t('profile.interests.title')}
+      />
+      <HelpingToolLinkItem
+        icon={<MdOutlineQuiz size={24} color="#006DB3" />}
+        title={t('tool.interests.riasec-test')}
+        component={({ children }) => <div className="bg-todo">{children}</div>}
+      />
+      <HelpingToolLinkItem
+        icon={<MdOutlineInterests size={24} color="#AD4298" />}
+        title={t('tool.interests.interest-barometer')}
+        component={({ children }) => <div className="bg-todo">{children}</div>}
+      />
+    </HelpingToolsContent>
   );
 };
 
@@ -97,7 +92,7 @@ const Interests = () => {
           {sm ? (
             <>
               <span className="text-heading-4 text-black">{t('tools')}</span>
-              <HelpingToolsContent />
+              <HelpingToolsContents />
             </>
           ) : (
             <Accordion
@@ -106,7 +101,7 @@ const Interests = () => {
               expandMoreText={t('expand-more')}
               lang={language}
             >
-              <HelpingToolsContent />
+              <HelpingToolsContents />
             </Accordion>
           )}
         </div>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Update the helping tools design
  - hover added to the items
  - increased the gap between icon and text
- Add reusable component to be used for the links
- Add `bg-todo` for the two links on Interests.

## Additional info
It would be possible to just use `HelpingToolLinkItem` also for the profile links (`HelpingToolProfileLinkItem`) but it looked nasty and introduced unwanted duplication.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-882
