### PR TITLE
OPHJOD-918: Change ehdotus tyomahdollisuudet API to mahdollisuudet

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -232,10 +232,10 @@ export interface paths {
       cookie?: never;
     };
     /** Finds all yksilon suosikit */
-    get: operations['yksilonSuosikkiGet'];
+    get: operations['yksilonSuosikkiFindAll'];
     put?: never;
     /** Add a Yksilo's suosikki */
-    post: operations['yksilonSuosikkiPost'];
+    post: operations['yksilonSuosikkiAdd'];
     /** Deletes one of Yksilo's suosikki */
     delete: operations['yksilonSuosikkiDelete'];
     options?: never;
@@ -279,22 +279,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/ehdotus/tyomahdollisuudet': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: operations['tyomahdollisuudetCreateEhdotus'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/ehdotus/osaamiset': {
     parameters: {
       query?: never;
@@ -305,6 +289,22 @@ export interface paths {
     get?: never;
     put?: never;
     post: operations['osaamisetEhdotusCreateEhdotus'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/ehdotus/mahdollisuudet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations['tyomahdollisuudetCreateEhdotus'];
     delete?: never;
     options?: never;
     head?: never;
@@ -546,6 +546,12 @@ export interface components {
       nimi: components['schemas']['LokalisoituTeksti'];
       koulutukset?: components['schemas']['KoulutusDto'][];
     };
+    Ehdotus: {
+      /** Format: uri */
+      uri: string;
+      /** Format: double */
+      osuvuus: number;
+    };
     LuoEhdotusDto: {
       /** Format: double */
       osaamisPainotus?: number;
@@ -563,15 +569,11 @@ export interface components {
       /** Format: double */
       pisteet?: number;
       /** @enum {string} */
+      tyyppi?: 'TYOMAHDOLLISUUS' | 'KOULUTUSMAHDOLLISUUS';
+      /** @enum {string} */
       trendi?: 'NOUSEVA' | 'LASKEVA';
       /** Format: int32 */
       tyollisyysNakyma?: number;
-    };
-    Ehdotus: {
-      /** Format: uri */
-      uri: string;
-      /** Format: double */
-      osuvuus: number;
     };
     SivuDtoTyomahdollisuusDto: {
       sisalto: components['schemas']['TyomahdollisuusDto'][];
@@ -1387,7 +1389,7 @@ export interface operations {
       };
     };
   };
-  yksilonSuosikkiGet: {
+  yksilonSuosikkiFindAll: {
     parameters: {
       query?: {
         tyyppi?: 'TYOMAHDOLLISUUS' | 'KOULUTUSMAHDOLLISUUS';
@@ -1409,7 +1411,7 @@ export interface operations {
       };
     };
   };
-  yksilonSuosikkiPost: {
+  yksilonSuosikkiAdd: {
     parameters: {
       query?: never;
       header?: never;
@@ -1545,30 +1547,6 @@ export interface operations {
       };
     };
   };
-  tyomahdollisuudetCreateEhdotus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LuoEhdotusDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['EhdotusDto'][];
-        };
-      };
-    };
-  };
   osaamisetEhdotusCreateEhdotus: {
     parameters: {
       query?: never;
@@ -1589,6 +1567,30 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['Ehdotus'][];
+        };
+      };
+    };
+  };
+  tyomahdollisuudetCreateEhdotus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LuoEhdotusDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['EhdotusDto'][];
         };
       };
     };

--- a/src/components/OpportunityCard/OpportunityCard.tsx
+++ b/src/components/OpportunityCard/OpportunityCard.tsx
@@ -42,7 +42,7 @@ const Match = ({ match, label, bg }: { match?: number; label: string; bg: string
     <div
       className={`${bg} flex flex-row shrink-0 sm:flex-col rounded-lg sm:rounded-[40px] sm:min-h-[80px] w-[132px] sm:w-[80px] h-[32px] text-white justify-center text-center items-center sm:mt-3`}
     >
-      {match !== undefined && match > 0 && (
+      {match !== undefined && match >= 0 && (
         <>
           <span className="mr-3 sm:mr-0 text-heading-2-mobile sm:text-heading-2">{Math.round(match * 100)}%</span>
           <span className="flex justify-center text-body-xs font-arial font-bold">{label}</span>
@@ -215,8 +215,10 @@ export const OpportunityCard = ({
       <div className="rounded shadow-border bg-white pt-5 pr-5 pl-5 sm:pl-6 pb-5 sm:pb-7">
         <div className="flex flex-col sm:flex-row sm:gap-5">
           <div className="flex flex-row justify-between align-center">
-            <div className={type !== 'work' ? 'bg-todo' : undefined}>
-              {matchValue && matchLabel && <Match match={matchValue} label={matchLabel} bg={bgForType(type)} />}
+            <div>
+              {typeof matchValue === 'number' && matchLabel && (
+                <Match match={matchValue} label={matchLabel} bg={bgForType(type)} />
+              )}
             </div>
             {!sm && ActionSection}
           </div>

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -87,7 +87,6 @@ const Tool = () => {
 
   // placeholder states
   const [showFilters, setShowFilters] = React.useState(false);
-  const [educationsCount] = React.useState(1002);
 
   const initialized = React.useRef(false);
   React.useEffect(() => {
@@ -254,8 +253,8 @@ const Tool = () => {
                 {t('tool.competences.opportunities-title')}
               </h2>
               {t('tool.competences.available-options-totals', {
-                professionsCount: toolStore.ehdotuksetCount,
-                educationsCount,
+                professionsCount: toolStore.ehdotuksetCount.TYOMAHDOLLISUUS,
+                educationsCount: toolStore.ehdotuksetCount.KOULUTUSMAHDOLLISUUS,
               })}
             </span>
           </div>
@@ -320,16 +319,13 @@ const Tool = () => {
           <div className="flex flex-col gap-5 mb-8">
             {toolStore.mixedMahdollisuudet.map((mahdollisuus) => {
               const { id } = mahdollisuus;
+              const ehdotus = toolStore.mahdollisuusEhdotukset?.[id];
               const isFavorite = toolStore.suosikit?.find((s) => s.suosionKohdeId === id) !== undefined;
-              // TODO: mahdollisuus tyyppi will be available in mahdollisuus ehdotukset
-              const mahdollisuusTyyppi = toolStore.tyomahdollisuudet.find((m) => m.id === id)
-                ? 'TYOMAHDOLLISUUS'
-                : 'KOULUTUSMAHDOLLISUUS';
-              return (
+              return ehdotus ? (
                 <NavLink
                   key={id}
                   to={
-                    mahdollisuusTyyppi == 'TYOMAHDOLLISUUS'
+                    ehdotus.tyyppi === 'TYOMAHDOLLISUUS'
                       ? `/${i18n.language}/${t('slugs.job-opportunity.index')}/${id}/${t('slugs.job-opportunity.overview')}`
                       : `/${i18n.language}/${t('slugs.education-opportunity.index')}/${id}/${t('slugs.education-opportunity.overview')}`
                   }
@@ -342,17 +338,17 @@ const Tool = () => {
                     selected={toolStore.mahdollisuudet.includes(id)}
                     name={getLocalizedText(mahdollisuus.otsikko)}
                     description={getLocalizedText(mahdollisuus.tiivistelma)}
-                    matchValue={toolStore.mahdollisuusEhdotukset?.[id]?.pisteet}
+                    matchValue={ehdotus?.pisteet}
                     matchLabel={t('fit')}
-                    type={mahdollisuusTyyppi === 'TYOMAHDOLLISUUS' ? 'work' : 'education'}
-                    trend={toolStore.mahdollisuusEhdotukset?.[id]?.trendi}
-                    employmentOutlook={toolStore.mahdollisuusEhdotukset?.[id]?.tyollisyysNakyma ?? 0}
+                    type={ehdotus.tyyppi === 'TYOMAHDOLLISUUS' ? 'work' : 'education'}
+                    trend={ehdotus?.trendi}
+                    employmentOutlook={ehdotus?.tyollisyysNakyma ?? 0}
                     hasRestrictions
                     industryName="TODO: Lorem ipsum dolor"
                     mostCommonEducationBackground="TODO: Lorem ipsum dolor"
                   />
                 </NavLink>
-              );
+              ) : null;
             })}
           </div>
 
@@ -366,7 +362,7 @@ const Tool = () => {
                 nextTriggerLabel: t('pagination.next'),
                 prevTriggerLabel: t('pagination.previous'),
               }}
-              totalItems={toolStore.ehdotuksetCount}
+              totalItems={toolStore.ehdotuksetCount.KOULUTUSMAHDOLLISUUS + toolStore.ehdotuksetCount.TYOMAHDOLLISUUS}
               onPageChange={(data) => void onPageChange(data)}
             />
           )}

--- a/src/routes/Tool/utils.ts
+++ b/src/routes/Tool/utils.ts
@@ -1,23 +1,12 @@
-export interface EhdotusData {
-  /** Format: uuid */
-  mahdollisuusId: string;
-  ehdotusMetadata?: EhdotusMetadata;
-}
+import { components } from '@/api/schema';
 
-export interface EhdotusMetadata {
-  /** Format: double */
-  pisteet?: number;
-  /** @enum {string} */
-  trendi?: 'NOUSEVA' | 'LASKEVA';
-  /** Format: int32 */
-  tyollisyysNakyma?: number;
-}
+export type EhdotusRecord = Record<string, components['schemas']['EhdotusMetadata']>;
 
-export type EhdotusRecord = Record<string, EhdotusMetadata>;
-
-export const ehdotusDataToRecord = (array: EhdotusData[]): EhdotusRecord => {
+export const ehdotusDataToRecord = (array: components['schemas']['EhdotusDto'][]): EhdotusRecord => {
   return array.reduce((acc, item) => {
-    acc[item.mahdollisuusId] = item?.ehdotusMetadata ?? {};
+    if (item.mahdollisuusId) {
+      acc[item.mahdollisuusId] = item?.ehdotusMetadata ?? {};
+    }
     return acc;
   }, {} as EhdotusRecord);
 };


### PR DESCRIPTION
## Description

Used changed backend endpoint /api/ehdotukset/tyomahdollisuudet ->  /api/ehdotukset/mahdollisuudet
Handles opportunities with type of opportunity TYOMAHDOLLISUUS or KOULUTUSMAHDOLLISUUS.
![image](https://github.com/user-attachments/assets/a2af905a-b738-4275-b6ea-89b30d110498)

![image](https://github.com/user-attachments/assets/77f2ed44-cfc9-4560-bd06-3e8c1b268935)

Fixed handling of opportunity 0% and removed todo highlight related in koulutusmahdollisuus % implementation.
![image](https://github.com/user-attachments/assets/7fd66d80-b06a-4bea-a2fa-0efebb26dfe5)

Show related opportunity counts based on backend response.
![image](https://github.com/user-attachments/assets/2c3eef03-cbb0-45f1-8f6f-5242f5ff2ec5)



Backend implementation PR: https://github.com/Opetushallitus/jod-yksilo/pull/85

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-918
