### PR TITLE
OPHJOD-916: Update Favorites pages to change layout based on filters

### DIFF
--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -229,11 +229,16 @@
       "title": "Koulutukseni"
     },
     "favorites": {
+      "job-and-education-opportunities": "Työ- ja koulutusmahdollisuudet",
       "description": "Suosikeiksi tallentamasi koulutus- ja työmahdollisuudet löytyvät täältä. Voit tallentaa lisää mahdollisuuksia suosikeiksi kohtautuskoneen tulosnäkymässä. Voit poistaa suosikkeja sekä luoda yhdestä tai useammasta suosikista koulutus- ja urapolkusuunnitelman.",
       "title": "Suosikkini",
-      "you-have-saved-n-opportunities_one": "Olet tallentanut yhden mahdollisuuden suosikiksi",
-      "you-have-saved-n-opportunities_other": "Olet tallentanut {{count}} mahdollisuutta suosikiksi",
-      "you-have-saved-n-opportunities_zero": "Et ole vielä tallentanut yhtään mahdollisuutta suosikiksi"
+      "you-have-saved-opportunities": "Olet tallentanut {{jobOpportunitiesCount}} työmahdollisuutta ja {{educationOpportunitiesCount}} koulutusmahdollisuutta.",
+      "you-have-saved-n-education-opportunities_one": "Olet tallentanut yhden koulutusmahdollisuuden suosikiksi",
+      "you-have-saved-n-education-opportunities_other": "Olet tallentanut {{count}} koulutusmahdollisuutta suosikiksi",
+      "you-have-saved-n-education-opportunities_zero": "Et ole vielä tallentanut yhtään koulutusmahdollisuutta suosikiksi",
+      "you-have-saved-n-job-opportunities_one": "Olet tallentanut yhden työmahdollisuuden suosikiksi",
+      "you-have-saved-n-job-opportunities_other": "Olet tallentanut {{count}} työmahdollisuutta suosikiksi",
+      "you-have-saved-n-job-opportunities_zero": "Et ole vielä tallentanut yhtään työmahdollisuutta suosikiksi"
     },
     "free-time-activities": {
       "description": "Löydät alta vapaa-ajan toimintosi. Vapaa-ajan toimintoja voivat olla harrastukset, luottamustoimet sekä erilaiset pätevyydet. Voit lisätä käsin vapaa-ajan toimintojasi sekä kartoittaa niihin liittyviä osaamisiasi.",

--- a/src/stores/useSuosikitStore/index.ts
+++ b/src/stores/useSuosikitStore/index.ts
@@ -1,7 +1,7 @@
 import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { DEFAULT_PAGE_SIZE } from '@/constants';
-import { TypedMahdollisuus } from '@/routes/types';
+import { MahdollisuusTyyppi, TypedMahdollisuus } from '@/routes/types';
 import { paginate, sortByProperty } from '@/utils';
 import { PageChangeDetails } from '@jod/design-system';
 import { create } from 'zustand';
@@ -11,10 +11,10 @@ interface FavoritesState {
   suosikitLoading: boolean;
   pageNr: number;
   pageSize: number;
-  filters: string[];
   pageData: TypedMahdollisuus[];
+  filters: MahdollisuusTyyppi[];
 
-  setFilters: (state: string[]) => void;
+  setFilters: (state: MahdollisuusTyyppi[]) => void;
   setSuosikit: (state: components['schemas']['SuosikkiDto'][]) => void;
   setPageData: (state: TypedMahdollisuus[]) => void;
   fetchSuosikit: () => Promise<void>;
@@ -27,7 +27,7 @@ export const useSuosikitStore = create<FavoritesState>()((set, get) => ({
   suosikitLoading: false,
   pageNr: 1,
   pageSize: DEFAULT_PAGE_SIZE,
-  filters: [],
+  filters: ['TYOMAHDOLLISUUS', 'KOULUTUSMAHDOLLISUUS'],
   pageData: [],
   setSuosikit: (state) => set({ suosikit: state }),
   setPageData: (state) => set({ pageData: state }),


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Update Favorites page content based on selected filters.

## Additional info
One filter is wanted to be always selected; no case when zero filters are selected.
Now it prevents to remove the last filter on. Another option would be to toggle the filter in that case, but that might be weird to communicate for screenreader.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-916
