### PR TITLE
OPHJOD-944: Refactor Competence type logic

### DIFF
--- a/src/routes/Profile/Competences/Competences.tsx
+++ b/src/routes/Profile/Competences/Competences.tsx
@@ -6,7 +6,6 @@ import {
   Title,
   type RoutesNavigationListProps,
 } from '@/components';
-import { OsaaminenLahdeTyyppi } from '@/components/OsaamisSuosittelija/OsaamisSuosittelija';
 import { Filters } from '@/routes/Profile/Competences/Filters';
 import { GroupByAlphabet } from '@/routes/Profile/Competences/GroupByAlphabet';
 import { GroupBySource } from '@/routes/Profile/Competences/GroupBySource';
@@ -18,7 +17,14 @@ import { useTranslation } from 'react-i18next';
 import { MdTune } from 'react-icons/md';
 import { useLoaderData, useOutletContext } from 'react-router-dom';
 import { mapNavigationRoutes } from '../utils';
-import { FILTERS_ORDER, GROUP_BY_ALPHABET, GROUP_BY_SOURCE, GROUP_BY_THEME, type FiltersType } from './constants';
+import {
+  CompetenceFilter,
+  FILTERS_ORDER,
+  GROUP_BY_ALPHABET,
+  GROUP_BY_SOURCE,
+  GROUP_BY_THEME,
+  type FiltersType,
+} from './constants';
 
 interface Kokemus {
   id?: string;
@@ -44,14 +50,13 @@ const Competences = () => {
     KOULUTUS: [],
     PATEVYYS: [],
     MUU_OSAAMINEN: [],
-    KIINNOSTUS: [],
   });
   const [filterKeys, setFilterKeys] = React.useState<(keyof FiltersType)[]>([]);
   const [showFilters, setShowFilters] = React.useState(false);
   const { sm } = useMediaQueries();
 
   const mapExperienceToFilter = React.useCallback(
-    (currentFilters: FiltersType, type: OsaaminenLahdeTyyppi) => (experience: Kokemus) => ({
+    (currentFilters: FiltersType, type: CompetenceFilter) => (experience: Kokemus) => ({
       label: experience.nimi[locale] ?? '',
       value: experience.id ?? experience.uri ?? '',
       checked: currentFilters?.[type]?.find((item) => item.value === experience.id)?.checked ?? true,
@@ -102,7 +107,7 @@ const Competences = () => {
   // Determines if osaamiset from a specific source should be visible. Id is the id of the source (eg. koulutus or toimenkuva).
   // Muu osaaminen doesn't have any sources, so they'll show up if any are marked as checked.
   const isOsaaminenVisible = React.useCallback(
-    (type: OsaaminenLahdeTyyppi, id?: string): boolean => {
+    (type: CompetenceFilter, id?: string): boolean => {
       return type === 'MUU_OSAAMINEN'
         ? selectedFilters.MUU_OSAAMINEN.length > 0 && selectedFilters.MUU_OSAAMINEN.some((item) => item.checked)
         : selectedFilters[type]?.find((item) => item.value === id)?.checked ?? false;

--- a/src/routes/Profile/Competences/Filters.tsx
+++ b/src/routes/Profile/Competences/Filters.tsx
@@ -1,11 +1,11 @@
 import { SimpleNavigationList } from '@/components';
-import { OsaaminenLahdeTyyppi } from '@/components/OsaamisSuosittelija/OsaamisSuosittelija';
 import { OSAAMINEN_COLOR_MAP } from '@/constants';
 import {
+  CompetenceFilter,
+  FiltersType,
   GROUP_BY_ALPHABET,
   GROUP_BY_SOURCE,
   GROUP_BY_THEME,
-  type FiltersType,
 } from '@/routes/Profile/Competences/constants';
 import { Accordion, Checkbox, RadioButton, RadioButtonGroup, useMediaQueries } from '@jod/design-system';
 import React from 'react';
@@ -51,7 +51,7 @@ export const Filters = ({ groupBy, setGroupBy, filterKeys, selectedFilters, setS
   const { sm } = useMediaQueries();
 
   // Toggle single filter item
-  const toggleSingleFilter = (type: OsaaminenLahdeTyyppi, index: number) => () => {
+  const toggleSingleFilter = (type: CompetenceFilter, index: number) => () => {
     const newFilters = { ...selectedFilters };
     newFilters[type][index] = newFilters[type][index] ?? { checked: true };
     newFilters[type][index].checked = !newFilters[type][index].checked;
@@ -59,13 +59,13 @@ export const Filters = ({ groupBy, setGroupBy, filterKeys, selectedFilters, setS
   };
 
   // Check if any filter of a specific type is checked
-  const isFilterTypeChecked = (type: OsaaminenLahdeTyyppi) => {
+  const isFilterTypeChecked = (type: CompetenceFilter) => {
     const filter = selectedFilters[type];
     return (filter.length > 0 && filter?.some((item) => item.checked)) ?? false;
   };
 
   // Toggle all filters of a specific type
-  const toggleFiltersByType = (type: OsaaminenLahdeTyyppi) => () => {
+  const toggleFiltersByType = (type: CompetenceFilter) => () => {
     const newFilter = { ...selectedFilters };
     newFilter[type] = newFilter[type] ?? [];
 

--- a/src/routes/Profile/Competences/GroupBySource.tsx
+++ b/src/routes/Profile/Competences/GroupBySource.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { MdArrowForward } from 'react-icons/md';
 import { Link, useRouteLoaderData } from 'react-router-dom';
 import { generateProfileLink } from '../utils';
-import { COMPETENCE_TYPES, GroupByProps, MobileFilterButton, groupByHeaderClasses } from './constants';
+import { FILTERS_ORDER, GroupByProps, MobileFilterButton, groupByHeaderClasses } from './constants';
 
 export const GroupBySource = ({
   filters,
@@ -62,7 +62,7 @@ export const GroupBySource = ({
         {mobileFilterOpenerComponent}
       </div>
       <div className="mb-10">
-        {COMPETENCE_TYPES.map((competence) => {
+        {FILTERS_ORDER.map((competence) => {
           return (
             <React.Fragment key={competence}>
               <div className={groupByHeaderClasses}>{t(`my-competences.by-${competence}`)}</div>

--- a/src/routes/Profile/Competences/constants.ts
+++ b/src/routes/Profile/Competences/constants.ts
@@ -1,5 +1,4 @@
 import { components } from '@/api/schema';
-import { OsaaminenLahdeTyyppi } from '@/components/OsaamisSuosittelija/OsaamisSuosittelija';
 
 export const GROUP_BY_SOURCE = 'a';
 export const GROUP_BY_THEME = 'b';
@@ -12,16 +11,17 @@ export interface FilterData {
   checked: boolean;
 }
 
-export type FiltersType = Record<OsaaminenLahdeTyyppi, FilterData[]>;
-export const FILTERS_ORDER = ['TOIMENKUVA', 'KOULUTUS', 'PATEVYYS', 'KIINNOSTUS', 'MUU_OSAAMINEN'] as const;
-export const COMPETENCE_TYPES = ['TOIMENKUVA', 'KOULUTUS', 'PATEVYYS', 'MUU_OSAAMINEN'] as const;
+export const FILTERS_ORDER = ['TOIMENKUVA', 'KOULUTUS', 'PATEVYYS', 'MUU_OSAAMINEN'] as const;
+export type CompetenceFilter = (typeof FILTERS_ORDER)[number];
+
+export type FiltersType = Record<CompetenceFilter, FilterData[]>;
 
 export interface GroupByProps {
   filters: FiltersType;
   filterKeys: (keyof FiltersType)[];
   locale: 'fi' | 'sv';
   osaamiset: components['schemas']['YksilonOsaaminenDto'][];
-  isOsaaminenVisible: (key: OsaaminenLahdeTyyppi, id?: string) => boolean;
+  isOsaaminenVisible: (key: CompetenceFilter, id?: string) => boolean;
 }
 
 export interface MobileFilterButton {


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Refactor the Competence typing logic related to filters.

No longer using `'KIINNOSTUS'` as one of the values for filters in Profile/Compentences as there is separate page for showing those (Kiinnostuksen kohteeni).


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-944
