### PR TITLE
OPHJOD-1044: Improve OpportunityCard accessibility for screenreader

### DIFF
--- a/src/components/OpportunityCard/OpportunityCard.tsx
+++ b/src/components/OpportunityCard/OpportunityCard.tsx
@@ -36,6 +36,7 @@ const BottomBox = ({
   children: React.ReactNode;
 }) => (
   <div
+    role="note"
     className={`font-arial border border-inactive-gray py-2 px-3 -mr-[1px] -mb-[1px] text-attrib-title flex flex-row items-center gap-2 ${className}`.trim()}
   >
     <span className="flex items-center mr-1">{title}</span>
@@ -45,7 +46,7 @@ const BottomBox = ({
 
 const OutlookDots = ({ outlook, ariaLabel }: { outlook: number; ariaLabel: string }) => (
   <div role="figure" className="flex flex-row gap-2" aria-label={ariaLabel}>
-    {Array.from({ length: outlook }).map((_, idx) => (
+    {Array.from({ length: 5 }).map((_, idx) => (
       /* eslint-disable-next-line sonarjs/no-array-index-key*/
       <div key={idx} className={`${idx < outlook ? 'bg-accent' : 'bg-accent-25'} w-4 h-4 rounded-full`} aria-hidden />
     ))}
@@ -149,8 +150,52 @@ export const OpportunityCard = ({
     <>
       {loginModalOpen && <LoginModal onClose={() => setLoginModalOpen(false)} isOpen={loginModalOpen} />}
       <Component className="flex flex-col bg-white p-5 sm:p-6 rounded shadow-border">
+        <div className="order-2 flex flex-col">
+          <span className="font-arial text-body-sm-mobile sm:text-body-sm leading-6 uppercase">{cardTypeTitle}</span>
+          <NavLink
+            to={to}
+            className="mb-2 text-heading-2-mobile sm:text-heading-2 hyphens-auto hover:underline hover:text-link"
+          >
+            {name}
+          </NavLink>
+          <p className="font-arial text-body-md-mobile sm:text-body-md">{description}</p>
+          <div className="flex flex-wrap mt-5">
+            <BottomBox title={t('opportunity-card.trend')} className="bg-todo">
+              {trend === 'NOUSEVA' ? (
+                <MdOutlineTrendingUp size={24} className="text-accent" aria-label={t(`opportunity-card.trend-up`)} />
+              ) : (
+                <MdOutlineTrendingDown
+                  size={24}
+                  className="text-accent"
+                  aria-label={t(`opportunity-card.trend-down`)}
+                />
+              )}
+            </BottomBox>
+            <BottomBox title={t('opportunity-card.employment-outlook')} className="bg-todo">
+              <OutlookDots
+                outlook={employmentOutlook}
+                ariaLabel={t('opportunity-card.outlook-value', { outlook: employmentOutlook })}
+              />
+            </BottomBox>
+            {hasRestrictions && (
+              <BottomBox title={t('opportunity-card.maybe-has-restrictions')} className="bg-todo">
+                <MdBlock className="text-accent" size={20} role="presentation" />
+              </BottomBox>
+            )}
+            {industryName && (
+              <BottomBox title={`${t('opportunity-card.industry-name')}:`} className="bg-todo">
+                <span className="font-bold">{industryName}</span>
+              </BottomBox>
+            )}
+            {mostCommonEducationBackground && (
+              <BottomBox title={`${t('opportunity-card.common-educational-background')}:`} className="bg-todo">
+                <span className="font-bold">{mostCommonEducationBackground}</span>
+              </BottomBox>
+            )}
+          </div>
+        </div>
         <div
-          className={`flex flex-wrap-reverse items-center gap-x-7 gap-y-5 mb-4 ${typeof matchValue === 'number' && matchLabel ? 'justify-between' : 'justify-end'}`}
+          className={`flex flex-wrap-reverse items-center gap-x-7 gap-y-5 mb-4 order-1 ${typeof matchValue === 'number' && matchLabel ? 'justify-between' : 'justify-end'}`}
         >
           {typeof matchValue === 'number' && matchLabel && (
             <div className="flex flex-nowrap gap-x-3 items-center px-4 bg-[#AD4298] rounded-full text-white select-none">
@@ -159,52 +204,6 @@ export const OpportunityCard = ({
             </div>
           )}
           {ActionsSection}
-        </div>
-        <div className="font-arial text-body-sm-mobile sm:text-body-sm leading-6 uppercase">{cardTypeTitle}</div>
-        <NavLink
-          to={to}
-          className="mb-2 text-heading-2-mobile sm:text-heading-2 hyphens-auto hover:underline hover:text-link"
-        >
-          {name}
-        </NavLink>
-        <p className="font-arial text-body-md-mobile sm:text-body-md">{description}</p>
-        <div className="flex flex-wrap mt-5">
-          <BottomBox title={t('opportunity-card.trend')} className="bg-todo">
-            {trend === 'NOUSEVA' ? (
-              <MdOutlineTrendingUp
-                size={24}
-                className="text-accent"
-                aria-label={t(`opportunity-card.trend-ascending`)}
-              />
-            ) : (
-              <MdOutlineTrendingDown
-                size={24}
-                className="text-accent"
-                aria-label={t(`opportunity-card.trend-descending`)}
-              />
-            )}
-          </BottomBox>
-          <BottomBox title={t('opportunity-card.employment-outlook')} className="bg-todo">
-            <OutlookDots
-              outlook={employmentOutlook}
-              ariaLabel={t('opportunity-card.outlook-value', { outlook: employmentOutlook })}
-            />
-          </BottomBox>
-          {hasRestrictions && (
-            <BottomBox title={t('opportunity-card.maybe-has-restrictions')} className="bg-todo">
-              <MdBlock className="text-accent" size={20} />
-            </BottomBox>
-          )}
-          {industryName && (
-            <BottomBox title={`${t('opportunity-card.idustry-name')}:`} className="bg-todo">
-              <span className="font-bold">{industryName}</span>
-            </BottomBox>
-          )}
-          {mostCommonEducationBackground && (
-            <BottomBox title={`${t('opportunity-card.common-educational-background')}:`} className="bg-todo">
-              <span className="font-bold">{mostCommonEducationBackground}</span>
-            </BottomBox>
-          )}
         </div>
       </Component>
     </>

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -188,7 +188,7 @@
   "opportunity-card": {
     "common-educational-background": "Yleisin koulutustausta",
     "employment-outlook": "Työllisyysnäkymä",
-    "idustry-name": "Toimialan nimi",
+    "industry-name": "Toimialan nimi",
     "maybe-has-restrictions": "Saattaa sisältää rajoitteita",
     "opportunities-title": "Mahdollisuutesi",
     "outlook-value": "{{outlook}}/5",


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Improves the **OpportunityCard** component's accessibility for screenreader by little.
- Fixed typo in translation key name
- Updated to use correct translation keys for trend icon
- Fixed bug, where employment outlook dots where not showing correctly.

## More info
Visual order should be same like before but when first arriving to the card, the heading is the first one to land (previously it landed on Favorite button).



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1044
