### PR TITLE
OPHJOD-1118: Show occupation group as localized text

### DIFF
--- a/src/routes/JobOpportunity/JobOpportunity.tsx
+++ b/src/routes/JobOpportunity/JobOpportunity.tsx
@@ -11,7 +11,7 @@ import {
 import { CompareCompetencesTable } from '@/components/CompareTable/CompareCompetencesTable';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useToolStore } from '@/stores/useToolStore';
-import { getLocalizedText } from '@/utils';
+import { getLocalizedText, getLocalizedTextByLang } from '@/utils';
 import { tidyClasses as tc } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +35,7 @@ const ScrollHeading = ({ title, heading, className }: ScrollHeadingProps) => {
 
 const JobOpportunity = () => {
   const { t } = useTranslation();
-  const { tyomahdollisuus, ammatit, osaamiset, isLoggedIn } = useLoaderData() as LoaderData;
+  const { tyomahdollisuus, ammatit, ammattiryhma, osaamiset, isLoggedIn } = useLoaderData() as LoaderData;
   const toolStore = useToolStore();
   const { isDev } = useEnvironment();
   const title = getLocalizedText(tyomahdollisuus?.otsikko);
@@ -164,7 +164,7 @@ const JobOpportunity = () => {
         </div>
         <div>
           <ScrollHeading title={t('job-opportunity.occupations.title')} heading="h2" className="text-heading-2" />
-          <ol className="list-decimal ml-7 text-body-lg font-medium text-black leading-7">
+          <ol className="list-decimal ml-7 mt-5 text-body-lg font-medium text-black leading-7">
             {ammatit.map((ammatti) => (
               <li
                 className="text-capitalize text-body"
@@ -179,7 +179,15 @@ const JobOpportunity = () => {
         {isDev && (
           <div>
             <ScrollHeading title={t('job-opportunity.professional-group')} heading="h2" className="text-heading-2" />
-            <p className="text-body-md font-arial mb-6 mt-4">{tyomahdollisuus?.ammattiryhma}</p>
+            <ul className="list-none ml-0 mt-5 text-body-lg font-medium text-black leading-7">
+              <li
+                className="text-capitalize text-body"
+                title={`${ammattiryhma?.uri}\n${getLocalizedTextByLang('en', ammattiryhma?.kuvaus)}`}
+                key={ammattiryhma?.uri}
+              >
+                {getLocalizedText(ammattiryhma?.nimi)}
+              </li>
+            </ul>
           </div>
         )}
         {isDev && (

--- a/src/routes/JobOpportunity/loader.ts
+++ b/src/routes/JobOpportunity/loader.ts
@@ -18,7 +18,7 @@ const loader = (async ({ request, params, context }) => {
   data?.jakaumat?.ammatti?.arvot?.sort((a, b) => b.osuus - a.osuus);
   data?.jakaumat?.osaaminen?.arvot?.sort((a, b) => b.osuus - a.osuus);
 
-  const [competences, occupations] = await Promise.all([
+  const [competences, occupations, occupationGroup] = await Promise.all([
     osaamiset.combine(
       data?.jakaumat?.osaaminen?.arvot,
       (value) => value.arvo,
@@ -31,13 +31,20 @@ const loader = (async ({ request, params, context }) => {
       (value, occupation) => ({ ...occupation, osuus: value.osuus }),
       request.signal,
     ),
+    ammatit.get(data?.ammattiryhma ?? '', request.signal),
   ]);
 
   if (context) {
     await useToolStore.getState().updateSuosikit();
   }
 
-  return { tyomahdollisuus: data, osaamiset: competences, ammatit: occupations, isLoggedIn: !!context };
+  return {
+    tyomahdollisuus: data,
+    osaamiset: competences,
+    ammatit: occupations,
+    ammattiryhma: occupationGroup,
+    isLoggedIn: !!context,
+  };
 }) satisfies LoaderFunction<components['schemas']['YksiloCsrfDto'] | null>;
 
 export type LoaderData = Awaited<ReturnType<typeof loader>>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 import { components } from '@/api/schema';
 import { DEFAULT_PAGE_SIZE } from '@/constants';
-import i18n from '@/i18n/config';
+import i18n, { LangCode } from '@/i18n/config';
 
 export const formatDate = (date: Date) => {
   const month = date.getMonth();
@@ -16,6 +16,17 @@ export const formatDate = (date: Date) => {
 export const getLocalizedText = (
   entry?: components['schemas']['LokalisoituTeksti'] | Record<string, string | undefined>,
 ) => entry?.[i18n.language] ?? '';
+
+/**
+ * Gets the localized text from an object.
+ * @param lang langcode
+ * @param entry Object with localized texts
+ * @returns The text in current i18next language
+ */
+export const getLocalizedTextByLang = (
+  lang: LangCode,
+  entry?: components['schemas']['LokalisoituTeksti'] | Record<string, string | undefined>,
+) => entry?.[lang] ?? '';
 
 type NestedKeyOf<ObjectType extends object> = {
   [Key in keyof ObjectType & (string | number)]: ObjectType[Key] extends object


### PR DESCRIPTION
## Description

Show occupation group as text and related esco-uri and description in english. ISCOGroups does not provide labels in fi an sv transtalation.
## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1118
