### PR TITLE
OPHJOD-1136: Update CompetenceFilters to use top-level

### DIFF
--- a/src/hooks/useInitializeFilters/index.ts
+++ b/src/hooks/useInitializeFilters/index.ts
@@ -1,30 +1,42 @@
 import { CompetenceFilter, FILTERS_ORDER, FiltersType } from '@/routes/Profile/Competences/constants';
+import { CompetenceDataGroup } from '@/routes/Profile/Competences/loader';
 import { Kokemus } from '@/routes/types';
 import React from 'react';
 
-const mapExperienceToFilter =
-  (locale: string) => (currentFilters: FiltersType, type: CompetenceFilter) => (experience: Kokemus) => ({
-    label: experience.nimi[locale] ?? '',
-    value: experience.id ?? experience.uri ?? '',
-    checked: currentFilters?.[type]?.find((item) => item.value === experience.id)?.checked ?? true,
-    competences: experience.osaamiset || [],
+const mapExperienceToFilter = (locale: string) => (currentFilters: FiltersType) => (experience: Kokemus) => ({
+  label: experience.nimi[locale] ?? '',
+  value: [experience.id ?? experience.uri ?? ''],
+  checked:
+    currentFilters?.['MUU_OSAAMINEN']?.find((item) => (experience.id ? item.value.includes(experience.id) : false))
+      ?.checked ?? true,
+  competences: experience.osaamiset || [],
+});
+
+const mapCompetenceDataGroupToFilter =
+  (locale: string) => (currentFilters: FiltersType, type: CompetenceFilter) => (cdg: CompetenceDataGroup) => ({
+    label: cdg.nimi[locale] ?? '',
+    value: cdg.data?.map((d) => d.id ?? '') ?? [],
+    checked:
+      currentFilters?.[type]?.find((filter) => (cdg.id ? filter.value.includes(cdg.id) : false))?.checked ?? true,
+    competences: cdg.data?.flatMap((d) => d.osaamiset ?? []) ?? [],
   });
 
 const initFilters = (
   locale: string,
   selectedFilters: FiltersType,
-  toimenkuvat: Kokemus[],
-  koulutukset: Kokemus[],
-  patevyydet: Kokemus[],
+  toimenkuvat: CompetenceDataGroup[],
+  koulutukset: CompetenceDataGroup[],
+  patevyydet: CompetenceDataGroup[],
   muutOsaamiset: Kokemus[],
 ): FiltersType => {
+  const mapCompetenceDataGroup = mapCompetenceDataGroupToFilter(locale);
   const mapExperience = mapExperienceToFilter(locale);
 
   const initialFilters = {
-    TOIMENKUVA: toimenkuvat.map(mapExperience(selectedFilters, 'TOIMENKUVA')),
-    KOULUTUS: koulutukset.map(mapExperience(selectedFilters, 'KOULUTUS')),
-    PATEVYYS: patevyydet.map(mapExperience(selectedFilters, 'PATEVYYS')),
-    MUU_OSAAMINEN: muutOsaamiset.map(mapExperience(selectedFilters, 'MUU_OSAAMINEN')),
+    TOIMENKUVA: toimenkuvat.map(mapCompetenceDataGroup(selectedFilters, 'TOIMENKUVA')),
+    KOULUTUS: koulutukset.map(mapCompetenceDataGroup(selectedFilters, 'KOULUTUS')),
+    PATEVYYS: patevyydet.map(mapCompetenceDataGroup(selectedFilters, 'PATEVYYS')),
+    MUU_OSAAMINEN: muutOsaamiset.map(mapExperience(selectedFilters)),
   };
 
   return initialFilters;
@@ -33,9 +45,9 @@ const initFilters = (
 export const useInitializeFilters = (
   locale: string,
   initialSelectedFilters: FiltersType,
-  toimenkuvat: Kokemus[],
-  koulutukset: Kokemus[],
-  patevyydet: Kokemus[],
+  toimenkuvat: CompetenceDataGroup[],
+  koulutukset: CompetenceDataGroup[],
+  patevyydet: CompetenceDataGroup[],
   muutOsaamiset: Kokemus[],
 ) => {
   const [initialized, setInitialized] = React.useState(false);

--- a/src/routes/Profile/Competences/CompetenceFilters.tsx
+++ b/src/routes/Profile/Competences/CompetenceFilters.tsx
@@ -85,14 +85,14 @@ export const CompetenceFilters = ({ filterKeys, selectedFilters, setSelectedFilt
               >
                 <ul className="gap-y-3 flex-col flex">
                   {selectedFilters[key]?.map((item, idx) => (
-                    <li className="pl-6" key={item.value}>
+                    <li className="pl-6" key={item.label}>
                       <Checkbox
                         name={item.label}
                         ariaLabel={`${key} ${item.label}`}
                         label={item.label}
                         checked={item.checked}
                         onChange={toggleSingleFilter(key, idx)}
-                        value={item.value}
+                        value={JSON.stringify(item.value)}
                       />
                     </li>
                   ))}

--- a/src/routes/Profile/Competences/Competences.tsx
+++ b/src/routes/Profile/Competences/Competences.tsx
@@ -68,7 +68,7 @@ const Competences = () => {
     (type: CompetenceFilter, id?: string): boolean => {
       return type === 'MUU_OSAAMINEN'
         ? selectedFilters.MUU_OSAAMINEN.length > 0 && selectedFilters.MUU_OSAAMINEN.some((item) => item.checked)
-        : (selectedFilters[type]?.find((item) => item.value === id)?.checked ?? false);
+        : (selectedFilters[type]?.find((item) => (id ? item.value.includes(id) : false))?.checked ?? false);
     },
     [selectedFilters],
   );

--- a/src/routes/Profile/Competences/constants.ts
+++ b/src/routes/Profile/Competences/constants.ts
@@ -5,9 +5,10 @@ export const GROUP_BY_THEME = 'b';
 export const GROUP_BY_ALPHABET = 'c';
 
 export const groupByHeaderClasses = 'mb-5 mt-8 pb-3 border-b border-border-gray truncate text-heading-3';
+
 export interface FilterData {
   label: string;
-  value: string;
+  value: string[];
   checked: boolean;
 }
 
@@ -23,7 +24,6 @@ export interface GroupByProps {
   osaamiset: components['schemas']['YksilonOsaaminenDto'][];
   isOsaaminenVisible: (key: CompetenceFilter, id?: string) => boolean;
 }
-
 export interface MobileFilterButton {
   mobileFilterOpenerComponent: React.ReactNode;
 }

--- a/src/routes/Profile/Competences/loader.ts
+++ b/src/routes/Profile/Competences/loader.ts
@@ -2,11 +2,20 @@ import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { LoaderFunction } from 'react-router';
 
+export interface CompetenceDataGroup {
+  id?: string;
+  nimi: components['schemas']['LokalisoituTeksti'];
+  data?:
+    | components['schemas']['ToimenkuvaDto'][]
+    | components['schemas']['PatevyysDto'][]
+    | components['schemas']['KoulutusDto'][];
+}
+
 export interface CompetencesLoaderData {
   osaamiset: components['schemas']['YksilonOsaaminenDto'][];
-  toimenkuvat: components['schemas']['ToimenkuvaDto'][];
-  koulutukset: components['schemas']['KoulutusDto'][];
-  patevyydet: components['schemas']['PatevyysDto'][];
+  toimenkuvat: CompetenceDataGroup[];
+  koulutukset: CompetenceDataGroup[];
+  patevyydet: CompetenceDataGroup[];
   muutOsaamiset: components['schemas']['OsaaminenDto'][];
 }
 
@@ -34,18 +43,30 @@ export default (async ({ request }) => {
     ]);
 
     const osaaminenLahdeIds = (osaamisetRes?.data?.filter((o) => o.lahde.id).map((o) => o.lahde.id) ?? []) as string[];
+
     const muutOsaamiset =
       osaamisetRes?.data?.filter((o) => o.lahde.tyyppi === 'MUU_OSAAMINEN').map((o) => o.osaaminen) ?? [];
 
     const toimenkuvat =
-      tyopaikatRes?.data?.flatMap((tyopaikka) => filterItems(tyopaikka.toimenkuvat ?? [], osaaminenLahdeIds)) ?? [];
+      tyopaikatRes?.data?.map((tyopaikka) => ({
+        id: tyopaikka.id,
+        nimi: tyopaikka.nimi,
+        data: filterItems(tyopaikka.toimenkuvat ?? [], osaaminenLahdeIds),
+      })) ?? [];
 
     const patevyydet =
-      vapaaAjanToiminnotRes?.data?.flatMap((toiminto) => filterItems(toiminto.patevyydet ?? [], osaaminenLahdeIds)) ??
-      [];
+      vapaaAjanToiminnotRes?.data?.map((toiminto) => ({
+        id: toiminto.id,
+        nimi: toiminto.nimi,
+        data: filterItems(toiminto.patevyydet ?? [], osaaminenLahdeIds),
+      })) ?? [];
 
     const koulutukset =
-      koulutRes?.data?.flatMap((koulu) => filterItems(koulu.koulutukset ?? [], osaaminenLahdeIds)) ?? [];
+      koulutRes?.data?.map((koulu) => ({
+        id: koulu.id,
+        nimi: koulu.nimi,
+        data: filterItems(koulu.koulutukset ?? [], osaaminenLahdeIds),
+      })) ?? [];
 
     return {
       osaamiset: osaamisetRes.data,

--- a/src/routes/Tool/Competences.tsx
+++ b/src/routes/Tool/Competences.tsx
@@ -115,11 +115,16 @@ const CompetenceImport = () => {
 
     const toBeImportedSkills = [
       ...osaamiset
-        .filter((osaaminen) =>
-          mappedSelectedCompetences.some((msc) =>
-            msc.tyyppi === 'MUU_OSAAMINEN' ? msc.id === osaaminen.osaaminen.uri : msc.id === osaaminen.lahde.id,
-          ),
-        )
+        .filter((osaaminen) => {
+          return mappedSelectedCompetences.some((msc) => {
+            if (msc.tyyppi === 'MUU_OSAAMINEN') {
+              return msc.id.includes(osaaminen.osaaminen.uri);
+            } else if (osaaminen.lahde.id) {
+              return msc.id.includes(osaaminen.lahde.id);
+            }
+            return false;
+          });
+        })
         .map((skill) => ({
           id: skill.osaaminen.uri,
           nimi: skill.osaaminen.nimi,


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Update CompetenceFilters to use top-level; show name of työpaikka, koulutus and toiminto not the bottom-levels anymore (toimenkuva, tutkinto, pätevyys)

## Screenshots

Using workplace as an example here
## Workplaces
<img width="600" alt="SCR-20241212-mulp-2" src="https://github.com/user-attachments/assets/fdc1baa9-f24c-4cfd-a2a1-2f63d2a84ca8" />

## Filters after
<img width="600" alt="SCR-20241212-mupe-2" src="https://github.com/user-attachments/assets/fcda4446-41bd-48f4-8f14-a2068e1cd3cd" />

## Filters before
<img width="600" alt="SCR-20241212-mvmg-2" src="https://github.com/user-attachments/assets/b80c0adb-7db6-4bc3-942d-8a7a3a348a58" />

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1136
