### PR TITLE
OPHJOD-1133: Change alphabetical filtering

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -590,6 +590,8 @@ export interface components {
       trendi?: 'NOUSEVA' | 'LASKEVA';
       /** Format: int32 */
       tyollisyysNakyma?: number;
+      /** Format: int32 */
+      aakkosIndeksi: number;
     };
     SivuDtoTyomahdollisuusDto: {
       sisalto: components['schemas']['TyomahdollisuusDto'][];
@@ -1612,8 +1614,12 @@ export interface operations {
   };
   mahdollisuudetCreateEhdotus: {
     parameters: {
-      query?: never;
-      header?: never;
+      query?: {
+        sort?: 'ASC' | 'DESC';
+      };
+      header?: {
+        'Content-Language'?: 'fi' | 'sv' | 'en';
+      };
       path?: never;
       cookie?: never;
     };

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -186,7 +186,7 @@ const YourOpportunitiesPagination = ({
     }
   };
 
-  return toolStore.tyomahdollisuudet.length > 0 ? (
+  return toolStore.mixedMahdollisuudet.length > 0 ? (
     <div className={className}>
       <Pagination
         currentPage={toolStore.ehdotuksetPageNr}
@@ -198,7 +198,7 @@ const YourOpportunitiesPagination = ({
           nextTriggerLabel: t('pagination.next'),
           prevTriggerLabel: t('pagination.previous'),
         }}
-        totalItems={toolStore.ehdotuksetCount.KOULUTUSMAHDOLLISUUS + toolStore.ehdotuksetCount.TYOMAHDOLLISUUS}
+        totalItems={toolStore.itemCount}
         onPageChange={(data) => void onPageChange(data)}
       />
     </div>


### PR DESCRIPTION
## Description

Implementation of alphabetical sorting and paging of opportunities. Fixed page count when filtering is applied. 
Implementation uses the lexical order property of ehdotusDto to fetch page of sorted IDs from työ- and koulutusmahdollisuudet APIs. 

This pull request requires backend PR: 

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1133
