### PR TITLE
OPHJOD-1176: Fetch koski jakolinkki data

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -486,6 +486,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/integraatiot/koski': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Try to import data from koski link */
+    get: operations['integraatioGetKoskiData'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/ammatit': {
     parameters: {
       query?: never;
@@ -1970,6 +1987,28 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['KoulutusmahdollisuusFullDto'];
+        };
+      };
+    };
+  };
+  integraatioGetKoskiData: {
+    parameters: {
+      query: {
+        jakolinkki: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['KoulutusDto'][];
         };
       };
     };

--- a/src/components/ExperienceTable/ExperienceTable.tsx
+++ b/src/components/ExperienceTable/ExperienceTable.tsx
@@ -12,6 +12,13 @@ interface ExperienceTableProps {
   onRowClick?: (row: ExperienceTableRowData) => void;
   onNestedRowClick?: (row: ExperienceTableRowData) => void;
   onAddNestedRowClick?: (row: ExperienceTableRowData) => void;
+  hideOsaamiset?: boolean;
+  rowActionElement?: React.ReactNode;
+  useConfirm?: boolean;
+  confirmTitle?: string;
+  confirmRowDescription?: string;
+  confirmSubRowDescription?: string;
+  actionLabel?: string;
 }
 
 export const ExperienceTable = ({
@@ -23,6 +30,13 @@ export const ExperienceTable = ({
   onRowClick,
   onNestedRowClick,
   onAddNestedRowClick,
+  hideOsaamiset,
+  rowActionElement,
+  useConfirm,
+  confirmTitle,
+  confirmRowDescription,
+  confirmSubRowDescription,
+  actionLabel,
 }: ExperienceTableProps) => {
   const { t } = useTranslation();
   const { sm } = useMediaQueries();
@@ -47,9 +61,11 @@ export const ExperienceTable = ({
                   <th scope="col" className="pr-7 pb-3">
                     {t('ended')}
                   </th>
-                  <th scope="col" className={`pb-3 ${onNestedRowClick ? 'pr-7' : 'pr-5'}`.trim()}>
-                    {t('competences')}
-                  </th>
+                  {!hideOsaamiset && (
+                    <th scope="col" className={`pb-3 ${onNestedRowClick ? 'pr-7' : 'pr-5'}`.trim()}>
+                      {t('competences')}
+                    </th>
+                  )}
                 </>
               )}
             </tr>
@@ -62,6 +78,12 @@ export const ExperienceTable = ({
                   row={row}
                   onRowClick={onRowClick}
                   className="bg-white border-spacing-x-2"
+                  hideOsaamiset={hideOsaamiset}
+                  rowActionElement={rowActionElement}
+                  useConfirm={useConfirm}
+                  confirmTitle={confirmTitle}
+                  confirmDescription={confirmRowDescription}
+                  actionLabel={actionLabel}
                 />
                 {row.subrows?.map((subrow, i) => (
                   <ExperienceTableRow
@@ -71,6 +93,12 @@ export const ExperienceTable = ({
                     onRowClick={onNestedRowClick}
                     className={i % 2 !== 0 ? 'bg-white bg-opacity-60' : 'bg-bg-gray'}
                     nested
+                    hideOsaamiset={hideOsaamiset}
+                    rowActionElement={rowActionElement}
+                    useConfirm={useConfirm}
+                    confirmTitle={confirmTitle}
+                    confirmDescription={confirmSubRowDescription}
+                    actionLabel={actionLabel}
                   />
                 ))}
                 {onAddNestedRowClick && addNewNestedLabel && (
@@ -99,7 +127,17 @@ export const ExperienceTable = ({
               </tr>
             )}
             {uncategorizedRows.map((row) => (
-              <ExperienceTableRow key={row.key} row={row} onRowClick={onRowClick} />
+              <ExperienceTableRow
+                key={row.key}
+                row={row}
+                onRowClick={onRowClick}
+                hideOsaamiset={hideOsaamiset}
+                rowActionElement={rowActionElement}
+                useConfirm={useConfirm}
+                confirmTitle={confirmTitle}
+                confirmDescription={confirmRowDescription}
+                actionLabel={actionLabel}
+              />
             ))}
           </tbody>
         </table>

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -68,6 +68,20 @@
     "identify-competences": "Tunnista osaamisia",
     "name-of-degree-or-education": "Tutkinnon tai koulutuksen nimi"
   },
+  "education-import": {
+    "share-link": "Opintopolun jakolinkki",
+    "invalid-share-link": "Tarkasta opintopolun jakolinkki",
+    "data-header": "Opintopolusta löytyneet koulutukset",
+    "data-info": "Voit poistaa listasta ne koulutukset, joita et halua tuoda omaan osaamisprofiiliisi.",
+    "data-loading": "Ladataan tietoja opintopolusta...",
+    "data-load-failed": "Tietojen lataaminen epäonnistui",
+    "data-load-retry": "Yritä uudelleen",
+    "data-hint": "Käy luomassa Opintopolku-palvelussa jakolinkki ja liitä se tälle sivulle.",
+    "confirm-delete-title": "En halua lisätä tätä tietoa omaan osaamisprofiilini",
+    "confirm-delete-oppilaitos": "Oletko varma, että et halua lisätä tätä oppilaitosta ja siellä suoritettuja kolutuksia omaan osaamisprofiiliisi?",
+    "confirm-delete-education": "Oletko varma, että et halua lisätä tätä koulutusta/ tutkintoa omaan osaamisprofiiliisi?",
+    "education-or-degree": "Oppilaitos / tutkinto"
+  },
   "education-opportunities": "Koulutusmahdollisuudet",
   "education-opportunity": {
     "specific-professional-competences": {

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -9,12 +9,14 @@ import {
 } from '@/components';
 import { EducationHistoryWizard } from '@/routes/Profile/EducationHistory/EducationHistoryWizard';
 import EditKoulutuskokonaisuusModal from '@/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal';
+import { Button } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoaderData, useOutletContext, useRevalidator } from 'react-router';
 import { mapNavigationRoutes } from '../utils';
 import AddOrEditKoulutusModal from './modals/AddOrEditKoulutusModal';
-import { Koulutuskokonaisuus, getEducationHistoryTableRows } from './utils';
+import ImportKoskiModal from './modals/ImportKoskiModal';
+import { getEducationHistoryTableRows, Koulutuskokonaisuus } from './utils';
 
 const EducationHistory = () => {
   const routes = useOutletContext<RoutesNavigationListProps['routes']>();
@@ -37,6 +39,7 @@ const EducationHistory = () => {
   const [isKoulutusOpen, setIsKoulutusOpen] = React.useState(false);
   const [koulutusId, setKoulutusId] = React.useState<string | undefined>(undefined);
   const [koulutuskokonaisuusId, setKoulutuskokonaisuusId] = React.useState<string | undefined>(undefined);
+  const [koskiModalOpen, setKoskiModalOpen] = React.useState(false);
   const [rows, setRows] = React.useState<ExperienceTableRowData[]>(
     getEducationHistoryTableRows(koulutuskokonaisuudet, osaamisetMap),
   );
@@ -82,6 +85,10 @@ const EducationHistory = () => {
     revalidator.revalidate();
   };
 
+  const importFromKoski = () => {
+    setKoskiModalOpen(true);
+  };
+
   return (
     <MainLayout
       navChildren={
@@ -119,6 +126,16 @@ const EducationHistory = () => {
         />
       )}
       {isWizardOpen && <EducationHistoryWizard isOpen={isWizardOpen} onClose={onCloseWizard} />}
+      <div className="my-5">
+        <Button variant="white" label="Tuo tiedot Opintopolusta" onClick={importFromKoski} />
+      </div>
+      <ImportKoskiModal
+        isOpen={koskiModalOpen}
+        onClose={() => {
+          setKoskiModalOpen(false);
+          revalidator.revalidate();
+        }}
+      />
     </MainLayout>
   );
 };

--- a/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
@@ -1,0 +1,302 @@
+import { client } from '@/api/client';
+import { components } from '@/api/schema';
+import { ExperienceTable, ExperienceTableRowData } from '@/components';
+import { Button, InputField, Modal, Spinner, WizardProgress } from '@jod/design-system';
+import { t } from 'i18next';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdDelete } from 'react-icons/md';
+import { Link } from 'react-router';
+import { getEducationHistoryTableRows, Koulutus } from '../utils';
+
+interface ImportKoskiModalProps {
+  isOpen: boolean;
+  onClose: React.Dispatch<React.SetStateAction<void>>;
+}
+
+// Util functions
+const isValidUrl = (url?: string): boolean => {
+  try {
+    if (!url) {
+      return false;
+    }
+    // Parse the URL
+    const parsedUrl = new URL(url);
+
+    // Check if the protocol is HTTPS
+    if (parsedUrl.protocol !== 'https:') {
+      return false;
+    }
+
+    // Regular expression to validate the domain
+    const domainRegex = /^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+
+    // Extract the hostname and validate it
+    const hostname = parsedUrl.hostname;
+    return !!domainRegex.test(hostname) && (hostname === 'testiopintopolku.fi' || hostname === 'opintopolku.fi');
+  } catch (_) {
+    // If URL parsing fails, it's not a valid URL
+    return false;
+  }
+};
+
+// Main step with inputfield
+const MainStep = ({
+  jakolinkki,
+  setJakolinkki,
+}: {
+  jakolinkki?: string;
+  setJakolinkki: React.Dispatch<React.SetStateAction<string | undefined>>;
+}) => {
+  return (
+    <>
+      <h2 className="mb-4 text-heading-3 text-black sm:mb-5 sm:text-heading-2">{t('education-import.share-link')}</h2>
+      <div className="mb-6">
+        <InputField
+          label={t('education-import.share-link')}
+          onChange={(event) => {
+            setJakolinkki(event.target.value);
+          }}
+          help={!isValidUrl(jakolinkki) ? t('education-import.invalid-share-link') : ''}
+          value={jakolinkki}
+        />
+      </div>
+    </>
+  );
+};
+
+// Second step to select koski data to be saved into the profile
+const KoskiDataStep = ({
+  rows,
+  isLoading,
+  error,
+  reload,
+  onRowClick,
+}: {
+  rows?: ExperienceTableRowData[];
+  isLoading: boolean;
+  error?: Error;
+  reload: () => void;
+  onRowClick: (row: ExperienceTableRowData) => void;
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <h2 className="mb-4 text-heading-3 text-black sm:mb-5 sm:text-heading-2">{t('education-import.data-header')}</h2>
+      <p className="mb-4 text-body-sm text-black sm:mb-5 sm:text-body-sm">{t('education-import.data-info')}</p>
+      {isLoading && (
+        <div className="flex">
+          <Spinner className="mr-5 mb-5" size={24} color={'accent'} />
+          {t('education-import.data-loading')}
+        </div>
+      )}
+      {error && (
+        <div className="flex">
+          <p className="content-center mr-5"> {t('education-import.data-load-failed')}</p>
+          <Button variant="accent" label={t('education-import.data-load-retry')} onClick={reload} />
+        </div>
+      )}
+      {rows && (
+        <ExperienceTable
+          mainColumnHeader={t('education-import.education-or-degree')}
+          rows={rows}
+          hideOsaamiset
+          rowActionElement={<MdDelete size={24} className="fill-[#006DB3]" />}
+          onRowClick={onRowClick}
+          onNestedRowClick={onRowClick}
+          useConfirm
+          confirmTitle={t('education-import.confirm-delete-title')}
+          confirmRowDescription={t('education-import.confirm-delete-oppilaitos')}
+          confirmSubRowDescription={t('education-import.confirm-delete-education')}
+          actionLabel={t('delete')}
+        />
+      )}
+    </>
+  );
+};
+
+const ImportKoskiModal = ({ isOpen, onClose }: ImportKoskiModalProps) => {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [koskiFetchError, setError] = React.useState<Error | undefined>(undefined);
+  const [jakolinkki, setJakolinkki] = React.useState<string | undefined>(undefined);
+  const [koskiData, setKoskiData] = React.useState<components['schemas']['KoulutusDto'][] | undefined>(undefined);
+  const [step, setStep] = React.useState(0);
+  const stepComponents = [MainStep, KoskiDataStep];
+  const StepComponent = stepComponents[step];
+
+  const nextStep = () => {
+    fetchKoskiData();
+    setStep(step < stepComponents.length - 1 ? step + 1 : step);
+  };
+  const previousStep = () => {
+    setStep(step > 0 ? step - 1 : step);
+  };
+  const isLastStep = step === stepComponents.length - 1;
+  const isFirstStep = step === 0;
+
+  const deleteRow = (row: ExperienceTableRowData): void => {
+    let newKoskiData = koskiData;
+    if (row.subrows) {
+      row.subrows.forEach((r) => (newKoskiData = newKoskiData?.filter((d) => d.id !== r.key)));
+    } else {
+      newKoskiData = newKoskiData?.filter((d) => d.id !== row.key);
+    }
+    setKoskiData(newKoskiData);
+  };
+
+  const fetchKoskiData = async () => {
+    setIsLoading(true);
+    setKoskiData(undefined);
+    setError(undefined);
+    const { data, error } = await client.GET('/api/integraatiot/koski', {
+      params: { query: { jakolinkki: jakolinkki ?? '' } },
+    });
+
+    if (error) {
+      setKoskiData(undefined);
+      setIsLoading(false);
+      setError(error);
+    }
+
+    const d = data.map((k) => ({ id: `koski-${crypto.randomUUID()}`, ...k }));
+    setKoskiData(d);
+    setIsLoading(false);
+  };
+
+  const saveSelectedKoulutus = async () => {
+    const koulutusKokonaisuudet = new Map<string, Koulutus[]>();
+    koskiData?.forEach((k) => {
+      const key = JSON.stringify(k.nimi);
+      const koulutus = {
+        nimi: k.kuvaus as Record<string, string>,
+        alkuPvm: k.alkuPvm,
+        loppuPvm: k.loppuPvm,
+        osaamiset: [],
+      };
+      if (koulutusKokonaisuudet.has(key)) {
+        koulutusKokonaisuudet.get(key)?.push(koulutus);
+      } else {
+        koulutusKokonaisuudet.set(key, [koulutus]);
+      }
+    });
+    const entries = Array.from(koulutusKokonaisuudet);
+    await Promise.all(
+      entries
+        .map((entry) => ({ nimi: entry[0], koulutukset: entry[1] }))
+        .map((o) =>
+          client.POST('/api/profiili/koulutuskokonaisuudet', {
+            body: {
+              nimi: JSON.parse(o.nimi) as Record<string, string>,
+              koulutukset: o.koulutukset.map((koulutus) => ({
+                nimi: koulutus.nimi,
+                alkuPvm: koulutus.alkuPvm,
+                loppuPvm: koulutus.loppuPvm,
+                osaamiset: koulutus.osaamiset,
+              })),
+            },
+          }),
+        ),
+    );
+
+    close();
+  };
+
+  const convertKoskiDataToExperienceTableRows = (koskiData: components['schemas']['KoulutusDto'][] | undefined) => {
+    const koulutusKokonaisuudet = new Map<string, Koulutus[]>();
+    koskiData?.forEach((k) => {
+      const key = JSON.stringify(k.nimi);
+      const koulutus = {
+        id: k.id,
+        nimi: k.kuvaus as Record<string, string>,
+        alkuPvm: k.alkuPvm,
+        loppuPvm: k.loppuPvm,
+        osaamiset: [],
+      };
+      if (koulutusKokonaisuudet.has(key)) {
+        koulutusKokonaisuudet.get(key)?.push(koulutus);
+      } else {
+        koulutusKokonaisuudet.set(key, [koulutus]);
+      }
+    });
+    const entries = Array.from(koulutusKokonaisuudet);
+    const koulutuskokonaisuudet = entries
+      .map((entry) => ({ key: entry[0], koulutukset: entry[1] }))
+      .map((o, i) => ({
+        nimi: JSON.parse(o.key),
+        id: `${i}`,
+        koulutukset: o.koulutukset.map((koulutus) => ({
+          id: koulutus.id,
+          nimi: koulutus.nimi,
+          alkuPvm: koulutus.alkuPvm,
+          loppuPvm: koulutus.loppuPvm,
+          osaamiset: koulutus.osaamiset,
+        })),
+      }));
+    return getEducationHistoryTableRows(koulutuskokonaisuudet);
+  };
+
+  const close = () => {
+    setKoskiData(undefined);
+    setJakolinkki(undefined);
+    setStep(0);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      progress={
+        <WizardProgress
+          labelText={t('wizard.label')}
+          stepText={t('wizard.step')}
+          completedText={t('wizard.completed')}
+          currentText={t('wizard.current')}
+          steps={stepComponents.length}
+          currentStep={step + 1}
+        />
+      }
+      sidePanel={
+        <>
+          <p className="mb-4 text-black sm:mb-5 sm:text-heading-3">{t('education-import.data-hint')}</p>
+          <Link to={'https://www.opintopolku.fi'} target="_blank">
+            www.opintopolku.fi
+          </Link>
+        </>
+      }
+      content={
+        <StepComponent
+          jakolinkki={jakolinkki}
+          setJakolinkki={setJakolinkki}
+          rows={convertKoskiDataToExperienceTableRows(koskiData)}
+          isLoading={isLoading}
+          error={koskiFetchError}
+          reload={fetchKoskiData}
+          onRowClick={deleteRow}
+        />
+      }
+      footer={
+        <div className="flex flex-row justify-between">
+          <div className="flex flex-start justify-between gap-5">
+            <Button label={t('cancel')} variant="white" onClick={close} />
+            {!isFirstStep && <Button label={t('previous')} variant="white" onClick={previousStep} />}
+            {!isLastStep && (
+              <Button
+                label={t('next')}
+                variant="white"
+                disabled={isLastStep || isLoading || !jakolinkki || !isValidUrl(jakolinkki)}
+                onClick={nextStep}
+              />
+            )}
+            {isLastStep && (
+              <Button label={t('save')} variant="white" disabled={!koskiData} onClick={saveSelectedKoulutus} />
+            )}
+          </div>
+        </div>
+      }
+    />
+  );
+};
+
+export default ImportKoskiModal;


### PR DESCRIPTION
## Description

UI which provides possibility to import education from opintopolku by the opintopolku share link. 

This PR requires the backend implementation from PR: https://github.com/Opetushallitus/jod-yksilo/pull/98

E.g. link : https://testiopintopolku.fi/koski/opinnot/aktiiviset-ja-paattyneet-opinnot/9d811398176749bdbba3138772e8e6b7 can be used for the testing.

More links can be found from https://testiopintopolku.fi/koski/omattiedot when logged in as Nordea Demo test user.

UX design is POC. It provides selection of the imported data and possibility to save it to the profile.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1176
