### PR TITLE
OPHJOD-1216: Show job opportunity tasks in the list

### DIFF
--- a/src/routes/JobOpportunity/JobOpportunity.tsx
+++ b/src/routes/JobOpportunity/JobOpportunity.tsx
@@ -2,7 +2,7 @@ import { components } from '@/api/schema';
 import { CompareCompetencesTable } from '@/components/CompareTable/CompareCompetencesTable';
 import OpportunityDetails, { type OpportunityDetailsSection } from '@/components/OpportunityDetails/OpportunityDetails';
 import { useToolStore } from '@/stores/useToolStore';
-import { getLocalizedText } from '@/utils';
+import { getLocalizedText, hashString } from '@/utils';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoaderData } from 'react-router';
@@ -22,6 +22,13 @@ const JobOpportunity = () => {
   );
   const clusterSize = tyomahdollisuus?.jakaumat?.ammatti?.maara;
 
+  const tyomahdollisuusTehtavat =
+    getLocalizedText(tyomahdollisuus?.tehtavat) !== ''
+      ? getLocalizedText(tyomahdollisuus?.tehtavat)
+          .split('\n')
+          .sort((a, b) => a.localeCompare(b))
+      : [];
+
   const sections: OpportunityDetailsSection[] = [
     {
       navTitle: t('description'),
@@ -29,7 +36,16 @@ const JobOpportunity = () => {
     },
     {
       navTitle: t('job-opportunity.most-common-job-tasks.title'),
-      content: <p className="text-body-md font-arial">{getLocalizedText(tyomahdollisuus?.tehtavat)}</p>,
+      content: (
+        <ol className="list-decimal ml-7 text-body-lg font-medium text-black leading-7">
+          {tyomahdollisuusTehtavat.map((value, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={`${hashString(value)}-${index}`} className="text-capitalize text-body">
+              {value}
+            </li>
+          ))}
+        </ol>
+      ),
     },
     {
       navTitle: t('job-opportunity.occupations.title'),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -140,3 +140,13 @@ export const getDatePickerTranslations = (
   dayCell: (state): string => `${translations.actions.select} ${state.formattedDate}`,
   trigger: (open): string => (open ? translations.actions.close : translations.actions.open),
 });
+
+export const hashString = (str: string) => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+};


### PR DESCRIPTION
## Description

Show job opportunity task list in the list format on UI.

Backend PR changes the the työmahdollisuus imported list of tasks to line break separated string. This string is split back to a list on frontend and presented as defined in UX: design. 

![image](https://github.com/user-attachments/assets/842930cc-c215-445b-af2d-6175051bd157)


## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1216
