### PR TITLE
OPHJOD-1229: Fix ExperienceTable's buttons outline clipping

### DIFF
--- a/src/components/ExperienceTable/ExperienceTable.tsx
+++ b/src/components/ExperienceTable/ExperienceTable.tsx
@@ -45,7 +45,7 @@ export const ExperienceTable = ({
   const categorizedRows = rows.filter((row) => row.subrows);
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto pl-3">
       {rows.length > 0 && (
         <table className="w-full" border={0} cellPadding={0} cellSpacing={0}>
           <thead className="after:content-[''] after:block after:h-5">


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Fix ExperienceTable's buttons outlines getting clipped.

## Notes

It required minimum of `4.5px` to fix clipping, and the next available token is `8px`. 5px would be enough but then it would be another magic number hardcoded.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1229
