### PR TITLE
OPHJOD-1217 Koski OAuth2 integration UI changes

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -486,6 +486,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/integraatiot/koski/koulutukset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get import data from Koski */
+    get: operations['integraatioGetKoskiData'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/integraatiot/koski': {
     parameters: {
       query?: never;

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -88,6 +88,11 @@ const EducationHistory = () => {
     setKoskiModalOpen(true);
   };
 
+  const importFromKoskiOAuth = () => {
+    const currentUrl = encodeURIComponent(window.location.href);
+    window.location.href = `/yksilo/oauth2/authorize/koski?callback=${currentUrl}`;
+  };
+
   return (
     <MainLayout
       navChildren={
@@ -126,7 +131,9 @@ const EducationHistory = () => {
       )}
       {isWizardOpen && <EducationHistoryWizard isOpen={isWizardOpen} onClose={onCloseWizard} />}
       <div className="my-5">
-        <Button variant="white" label="Tuo tiedot Opintopolusta" onClick={importFromKoski} />
+        <Button variant="white" label="Tuo tiedot Opintopolusta jakolinkkillä" onClick={importFromKoski} />
+        <br />
+        <Button variant="white" label="Tuo tiedot Opintopolusta" onClick={importFromKoskiOAuth} />
       </div>
       <ImportKoskiModal
         isOpen={koskiModalOpen}
@@ -134,6 +141,7 @@ const EducationHistory = () => {
           setKoskiModalOpen(false);
           revalidator.revalidate();
         }}
+        setKoskiModalOpen={setKoskiModalOpen}
       />
     </MainLayout>
   );

--- a/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
@@ -136,7 +136,8 @@ const ImportKoskiModal = ({ isOpen, onClose, setKoskiModalOpen }: ImportKoskiMod
       setStep(step < stepComponents.length - 1 ? step + 1 : step);
       setKoskiModalOpen(true);
     }
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only need to run once after page is loaded.
 
   const nextStep = () => {
     fetchKoskiDataWithJakolinkki();

--- a/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
@@ -6,12 +6,13 @@ import { t } from 'i18next';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdDelete } from 'react-icons/md';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { getEducationHistoryTableRows, Koulutus } from '../utils';
 
 interface ImportKoskiModalProps {
   isOpen: boolean;
   onClose: React.Dispatch<React.SetStateAction<void>>;
+  setKoskiModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 // Util functions
@@ -116,7 +117,7 @@ const KoskiDataStep = ({
   );
 };
 
-const ImportKoskiModal = ({ isOpen, onClose }: ImportKoskiModalProps) => {
+const ImportKoskiModal = ({ isOpen, onClose, setKoskiModalOpen }: ImportKoskiModalProps) => {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = React.useState(false);
   const [koskiFetchError, setError] = React.useState<Error | undefined>(undefined);
@@ -125,9 +126,20 @@ const ImportKoskiModal = ({ isOpen, onClose }: ImportKoskiModalProps) => {
   const [step, setStep] = React.useState(0);
   const stepComponents = [MainStep, KoskiDataStep];
   const StepComponent = stepComponents[step];
+  const location = useLocation();
+
+  React.useEffect(() => {
+    const queryParams = new URLSearchParams(location.search);
+    if (queryParams.get('koski') === 'authorized') {
+      queryParams.delete('koski');
+      fetchKoskiDataWithOAuth2();
+      setStep(step < stepComponents.length - 1 ? step + 1 : step);
+      setKoskiModalOpen(true);
+    }
+  }, []);
 
   const nextStep = () => {
-    fetchKoskiData();
+    fetchKoskiDataWithJakolinkki();
     setStep(step < stepComponents.length - 1 ? step + 1 : step);
   };
   const previousStep = () => {
@@ -146,11 +158,19 @@ const ImportKoskiModal = ({ isOpen, onClose }: ImportKoskiModalProps) => {
     setKoskiData(newKoskiData);
   };
 
-  const fetchKoskiData = async () => {
+  const fetchKoskiDataWithJakolinkki = async () => {
+    fetchKoskiData('/api/integraatiot/koski');
+  };
+
+  const fetchKoskiDataWithOAuth2 = async () => {
+    fetchKoskiData('/api/integraatiot/koski/koulutukset');
+  };
+
+  const fetchKoskiData = async (endpoint: '/api/integraatiot/koski' | '/api/integraatiot/koski/koulutukset') => {
     setIsLoading(true);
     setKoskiData(undefined);
     setError(undefined);
-    const { data, error } = await client.GET('/api/integraatiot/koski', {
+    const { data, error } = await client.GET(endpoint, {
       params: { query: { jakolinkki: jakolinkki ?? '' } },
     });
 
@@ -272,7 +292,7 @@ const ImportKoskiModal = ({ isOpen, onClose }: ImportKoskiModalProps) => {
           rows={convertKoskiDataToExperienceTableRows(koskiData)}
           isLoading={isLoading}
           error={koskiFetchError}
-          reload={fetchKoskiData}
+          reload={fetchKoskiDataWithJakolinkki}
           onRowClick={deleteRow}
         />
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,22 @@ export default defineConfig({
         target,
         xfwd: true,
       },
+      '/yksilo/oauth2/authorize/koski': {
+        target,
+        xfwd: true,
+      },
+      '/yksilo/oauth2/authorization/koski': {
+        target,
+        xfwd: true,
+      },
+      '/yksilo/oauth2/response/koski': {
+        target,
+        xfwd: true,
+      },
+      '/api/integraatiot/koski/koulutukset': {
+        target,
+        xfwd: true,
+      },
       '/urataidot': {
         target: 'http://localhost:5173',
         xfwd: true,


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Add new "Tuo tiedot Opintopolusta"-button to trigger Koski OAuth2 process.
- Rename old "Tuo tiedot Opintopolusta" feature that user can import their education history through share link to "Tuo tiedot Opintopolusta jakolinkillä".

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1217
