### PR TITLE
OPHJOD-1283: Update WorkHistoryWizard to have ESC handler

### DIFF
--- a/src/components/LoginModal/LoginModal.tsx
+++ b/src/components/LoginModal/LoginModal.tsx
@@ -1,5 +1,7 @@
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { useLoginLink } from '@/hooks/useLoginLink';
 import { Button, Modal } from '@jod/design-system';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface LoginModalProps {
@@ -9,15 +11,17 @@ interface LoginModalProps {
 export const LoginModal = ({ onClose, isOpen }: LoginModalProps) => {
   const { t } = useTranslation();
   const loginLink = useLoginLink();
+  const contentId = React.useId();
+  useEscHandler(onClose, contentId);
 
   return (
     <Modal
       open={isOpen}
       content={
-        <>
+        <div id={contentId}>
           <h2 className="mb-4 text-heading-3 text-black sm:mb-5 sm:text-heading-2">{t('login')}</h2>
           <div className="mb-6">{t('login-for-favorites')}</div>
-        </>
+        </div>
       }
       footer={
         <div className="flex justify-end gap-5">

--- a/src/hooks/useEscHandler/index.ts
+++ b/src/hooks/useEscHandler/index.ts
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export const useEscHandler = (onEscKeyDown: () => void, parentElementId: string) => {
+  React.useEffect(() => {
+    const escHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        const activeElement = document.activeElement as HTMLElement;
+
+        // If active element is headless UI dialog, then it can be closed. Basically same if the focus would be in body-tag.
+        if (activeElement.id.includes('headlessui-dialog')) {
+          onEscKeyDown();
+          return;
+        }
+
+        const parentElement = document.getElementById(parentElementId);
+
+        if (parentElement) {
+          if (parentElement.contains(activeElement)) {
+            // If the active element is a child of the specified parent element, do nothing
+            return;
+          } else if (activeElement.tagName === 'BODY') {
+            onEscKeyDown();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', escHandler, true);
+
+    return () => {
+      document.removeEventListener('keydown', escHandler, true);
+    };
+  }, [onEscKeyDown, parentElementId]);
+};

--- a/src/hooks/useMenuClickHandler/index.ts
+++ b/src/hooks/useMenuClickHandler/index.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const useMenuClickHandler = (
-  handleOutsideClick: (event: MouseEvent) => void,
+  handleOutsideClick: (event: MouseEvent | KeyboardEvent) => void,
   menuButtonRef:
     | React.RefObject<HTMLButtonElement | null>
     | React.RefObject<HTMLLIElement | null>
@@ -42,6 +42,18 @@ export const useMenuClickHandler = (
       document.removeEventListener('mousedown', clickHandler, true);
     };
   }, [ref, handleOutsideClick, menuButtonRef, isPartOfHeadlessUIDialog]);
+
+  React.useEffect(() => {
+    const escHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleOutsideClick(event);
+      }
+    };
+    document.addEventListener('keydown', escHandler, true);
+    return () => {
+      document.removeEventListener('keydown', escHandler, true);
+    };
+  }, [handleOutsideClick]);
 
   return ref;
 };

--- a/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistoryWizard/EducationHistoryWizard.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/api/client';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal, useMediaQueries, WizardProgress } from '@jod/design-system';
 import React from 'react';
@@ -26,6 +27,8 @@ const EducationHistoryWizard = ({ isOpen, onClose }: EducationHistoryWizardProps
   const selectedKoulutus = React.useMemo(() => (step + (step % 2)) / 2 - 1, [step]);
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
+
   const methods = useForm<EducationHistoryForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/EducationHistory/modals/AddOrEditKoulutusModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/AddOrEditKoulutusModal.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { FormError, OsaamisSuosittelija, TouchedFormError } from '@/components';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { DatePickerTranslations, getDatePickerTranslations } from '@/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ConfirmDialog, Datepicker, InputField, Modal, WizardProgress } from '@jod/design-system';
@@ -147,6 +148,7 @@ const AddOrEditKoulutusModal = ({
   }
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
   const [step, setStep] = React.useState(0);
   const stepComponents = [MainStep, OsaamisetStep];
   const StepComponent = stepComponents[step];

--- a/src/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { FormError } from '@/components';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ConfirmDialog, InputField, Modal } from '@jod/design-system';
 import React from 'react';
@@ -33,6 +34,7 @@ const EditKoulutuskokonaisuusModal = ({
   } = useTranslation();
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
   const methods = useForm<KoulutuskokonaisuusForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoskiModal.tsx
@@ -1,6 +1,7 @@
 import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { ExperienceTable, ExperienceTableRowData } from '@/components';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { Button, InputField, Modal, Spinner, WizardProgress } from '@jod/design-system';
 import { t } from 'i18next';
 import React from 'react';
@@ -138,6 +139,7 @@ const ImportKoskiModal = ({ isOpen, onClose, setKoskiModalOpen }: ImportKoskiMod
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only need to run once after page is loaded.
+  const contentId = React.useId();
 
   const nextStep = () => {
     fetchKoskiDataWithJakolinkki();
@@ -264,6 +266,7 @@ const ImportKoskiModal = ({ isOpen, onClose, setKoskiModalOpen }: ImportKoskiMod
     setStep(0);
     onClose();
   };
+  useEscHandler(close, contentId);
 
   return (
     <Modal
@@ -287,15 +290,17 @@ const ImportKoskiModal = ({ isOpen, onClose, setKoskiModalOpen }: ImportKoskiMod
         </>
       }
       content={
-        <StepComponent
-          jakolinkki={jakolinkki}
-          setJakolinkki={setJakolinkki}
-          rows={convertKoskiDataToExperienceTableRows(koskiData)}
-          isLoading={isLoading}
-          error={koskiFetchError}
-          reload={fetchKoskiDataWithJakolinkki}
-          onRowClick={deleteRow}
-        />
+        <div id={contentId}>
+          <StepComponent
+            jakolinkki={jakolinkki}
+            setJakolinkki={setJakolinkki}
+            rows={convertKoskiDataToExperienceTableRows(koskiData)}
+            isLoading={isLoading}
+            error={koskiFetchError}
+            reload={fetchKoskiDataWithJakolinkki}
+            onRowClick={deleteRow}
+          />
+        </div>
       }
       footer={
         <div className="flex flex-row justify-between">

--- a/src/routes/Profile/FreeTimeActivities/FreeTimeActivitiesWizard/FreeTimeActivitiesWizard.tsx
+++ b/src/routes/Profile/FreeTimeActivities/FreeTimeActivitiesWizard/FreeTimeActivitiesWizard.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/api/client';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal, useMediaQueries, WizardProgress } from '@jod/design-system';
 import React from 'react';
@@ -24,6 +25,8 @@ const FreeTimeActivitiesWizard = ({ isOpen, setIsOpen }: FreeTimeActivitiesWizar
   const { sm } = useMediaQueries();
 
   const formId = React.useId();
+  useEscHandler(() => setIsOpen(false), formId);
+
   const methods = useForm<FreeTimeActivitiesForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/FreeTimeActivities/modals/AddOrEditPatevyysModal.tsx
+++ b/src/routes/Profile/FreeTimeActivities/modals/AddOrEditPatevyysModal.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { FormError, OsaamisSuosittelija, TouchedFormError } from '@/components';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { DatePickerTranslations, getDatePickerTranslations } from '@/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ConfirmDialog, Datepicker, InputField, Modal, WizardProgress } from '@jod/design-system';
@@ -152,6 +153,7 @@ export const AddOrEditPatevyysModal = ({
   }
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
   const [step, setStep] = React.useState(0);
   const stepComponents = [MainStep, OsaamisetStep];
   const StepComponent = stepComponents[step];

--- a/src/routes/Profile/FreeTimeActivities/modals/EditVapaaAjanToimintoModal.tsx
+++ b/src/routes/Profile/FreeTimeActivities/modals/EditVapaaAjanToimintoModal.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import type { components } from '@/api/schema';
 import { FormError } from '@/components';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ConfirmDialog, InputField, Modal } from '@jod/design-system';
 import React from 'react';
@@ -29,6 +30,7 @@ export const EditVapaaAjanToimintoModal = ({ isOpen, onClose, toimintoId: id }: 
   } = useTranslation();
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
   const methods = useForm<VapaaAjanToimintoForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/Interests/EditKiinnostusModal.tsx
+++ b/src/routes/Profile/Interests/EditKiinnostusModal.tsx
@@ -1,6 +1,7 @@
 import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { OsaaminenValue, OsaamisSuosittelija } from '@/components';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal } from '@jod/design-system';
 import React from 'react';
@@ -24,6 +25,8 @@ const EditInterestModal = ({ isOpen, onClose }: EditKiinnostusModalProps) => {
   const data = (useLoaderData() as components['schemas']['OsaaminenDto'][]) ?? [];
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
+
   const methods = useForm<KiinnostusForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/MyGoals/AddGoalModal.tsx
+++ b/src/routes/Profile/MyGoals/AddGoalModal.tsx
@@ -1,6 +1,7 @@
 import { OpportunityCard } from '@/components';
 import { MahdollisuusTyyppiFilter } from '@/components/MahdollisuusTyyppiFilter/MahdollisuusTyyppiFilter';
 import { FilterButton } from '@/components/MobileFilterButton/MobileFilterButton';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { useMenuClickHandler } from '@/hooks/useMenuClickHandler';
 import MyGoalsOpportunityCardMenu from '@/routes/Profile/MyGoals/MyGoalsOpportunityCardMenu';
 import { MahdollisuusTyyppi, TypedMahdollisuus } from '@/routes/types';
@@ -78,6 +79,9 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
   const paamaarat = usePaamaaratStore((state) => state.paamaarat);
   const [listItems, setListItems] = React.useState<TypedMahdollisuus[]>([]);
 
+  const goalsId = React.useId();
+  useEscHandler(onClose, goalsId);
+
   type SelectedFilter = 'KAIKKI' | 'TYOMAHDOLLISUUS' | 'KOULUTUSMAHDOLLISUUS';
 
   const selectedFilter: SelectedFilter = React.useMemo(() => {
@@ -149,11 +153,10 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
   return (
     <Modal
       open={isOpen}
-      onClose={onClose}
       content={
-        <>
+        <div id={goalsId}>
           <div>
-            <div className="sticky top-0 bg-bg-gray z-10 pb-3">
+            <div className="bg-bg-gray pb-3 relative">
               <h1 className="text-heading-1-mobile sm:text-heading-1">{t('profile.my-goals.add-modal-title')}</h1>
               <p className="text-body-sm-mobile sm:text-body-sm">{t('profile.my-goals.add-modal-description')}</p>
 
@@ -227,7 +230,7 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
               </div>
             )}
           </div>
-        </>
+        </div>
       }
       footer={
         <div className="flex justify-end">

--- a/src/routes/Profile/SomethingElse/EditMuuOsaaminenModal.tsx
+++ b/src/routes/Profile/SomethingElse/EditMuuOsaaminenModal.tsx
@@ -1,6 +1,7 @@
 import { client } from '@/api/client';
 import { OsaaminenDto } from '@/api/osaamiset';
 import { OsaaminenValue, OsaamisSuosittelija } from '@/components';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal } from '@jod/design-system';
 import React from 'react';
@@ -24,6 +25,8 @@ const EditMuuOsaaminenModal = ({ isOpen, onClose }: EditMuuOsaaminenModalProps) 
   const data = (useLoaderData() as OsaaminenDto[]) ?? [];
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
+
   const methods = useForm<OsaamisetForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistoryWizard/WorkHistoryWizard.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/api/client';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Modal, useMediaQueries, WizardProgress } from '@jod/design-system';
 import React from 'react';
@@ -26,6 +27,8 @@ const WorkHistoryWizard = ({ isOpen, onClose }: WorkHistoryWizardProps) => {
   const selectedToimenkuva = React.useMemo(() => (step + (step % 2)) / 2 - 1, [step]);
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
+
   const methods = useForm<WorkHistoryForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Profile/WorkHistory/modals/AddOrEditToimenkuvaModal.tsx
+++ b/src/routes/Profile/WorkHistory/modals/AddOrEditToimenkuvaModal.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { FormError, OsaamisSuosittelija, TouchedFormError } from '@/components';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { DatePickerTranslations, getDatePickerTranslations } from '@/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ConfirmDialog, Datepicker, InputField, Modal, WizardProgress } from '@jod/design-system';
@@ -146,6 +147,7 @@ const AddOrEditToimenkuvaModal = ({
   }
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
   const [step, setStep] = React.useState(0);
   const stepComponents = [MainStep, OsaamisetStep];
   const StepComponent = stepComponents[step];

--- a/src/routes/Profile/WorkHistory/modals/EditTyonantajaModal.tsx
+++ b/src/routes/Profile/WorkHistory/modals/EditTyonantajaModal.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import type { components } from '@/api/schema';
 import { FormError } from '@/components';
 import { formErrorMessage, LIMITS } from '@/constants';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, ConfirmDialog, InputField, Modal } from '@jod/design-system';
 import React from 'react';
@@ -29,6 +30,7 @@ const EditTyonantajaModal = ({ isOpen, onClose, tyopaikkaId: id }: EditTyonantaj
   } = useTranslation();
 
   const formId = React.useId();
+  useEscHandler(onClose, formId);
   const methods = useForm<TyonantajaForm>({
     mode: 'onBlur',
     resolver: zodResolver(

--- a/src/routes/Tool/VirtualAssistant.tsx
+++ b/src/routes/Tool/VirtualAssistant.tsx
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { OSAAMINEN_COLOR_MAP } from '@/constants';
 import { useEnvironment } from '@/hooks/useEnvironment';
+import { useEscHandler } from '@/hooks/useEscHandler';
 import { useToolStore } from '@/stores/useToolStore';
 import { removeDuplicates } from '@/utils';
 import { Button, Tag, Textarea, useMediaQueries } from '@jod/design-system';
@@ -33,8 +34,10 @@ export const VirtualAssistant = ({
   const containerRef = React.useRef<HTMLDivElement>(null);
   const { sm } = useMediaQueries();
   const [selectedKiinnostuksetViewVisible, setSelectedKiinnostuksetViewVisible] = React.useState(false);
-  const selectedKiinnostuksetViewId = React.useId();
+  const selectedKiinnostuksetLabelId = React.useId();
   const toolStore = useToolStore();
+  const selectedInterestsViewId = React.useId();
+  useEscHandler(() => setSelectedKiinnostuksetViewVisible(false), selectedInterestsViewId);
 
   const [selectedKiinnostukset, setSelectedKiinnostukset] = React.useState<components['schemas']['Kiinnostus'][]>([]);
 
@@ -241,10 +244,10 @@ export const VirtualAssistant = ({
         </div>
       </div>
       {selectedKiinnostuksetViewVisible && (
-        <div className="absolute top-0 w-full pt-6 h-full left-0 z-21">
+        <div id={selectedInterestsViewId} className="absolute top-0 w-full pt-6 h-full left-0 z-21">
           <div className="bg-white rounded shadow-[0_-1px_24px_rgba(0,0,0,0.25)] h-full flex flex-col">
             <button
-              aria-label={'tool.my-own-data.interests.virtual-assistant.close-selected-interests'}
+              aria-label={t('tool.my-own-data.interests.virtual-assistant.close-selected-interests')}
               onClick={() => setSelectedKiinnostuksetViewVisible(false)}
               className="absolute cursor-pointer self-end items-center p-4 m-3"
             >
@@ -253,12 +256,12 @@ export const VirtualAssistant = ({
               </span>
             </button>
             <div className="px-5 pt-9">
-              <h2 id={selectedKiinnostuksetViewId} className="text-heading-4-mobile sm:text-heading-4 text-center">
+              <h2 id={selectedKiinnostuksetLabelId} className="text-heading-4-mobile sm:text-heading-4 text-center">
                 {t('tool.my-own-data.interests.virtual-assistant.selected-interests')}
               </h2>
 
               <div
-                aria-labelledby={selectedKiinnostuksetViewId}
+                aria-labelledby={selectedKiinnostuksetLabelId}
                 className="min-h-[144px] overflow-y-auto rounded border border-border-gray p-5 bg-[#F7F7F9] mt-5"
               >
                 <div className="flex flex-wrap gap-3">


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Add ESC handler for the Modals in use.
- Pressing ESC will also close the menus (useMenuClickHandler)


## Note
The actual "permission" to close should have been checked in the given `onEscKeyDown` function. E.g like `WorkHistoryWizard` uses this same function to press "Cancel" button (currently no confirmations)

### Input
When Modal is open and focus is in input:
1. First ESC press will first remove the focus from the input.
2. Then focus automatically goes to the body
3. If then pressing ESC again, it will call the given `onEscKeyDown` function.

### DatePicker

When Modal is open and DatePicker is opened:
1. First ESC press will first close the calendar; focus returns to the calendar button
2. Second press will remove focus from the calendar button, and focus automatically goes to the body
4. If then pressing ESC again, it will call the given onEscKeyDown function.


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1283
