### PR TITLE
OPHJOD-1297: Update ExperienceTable to not clip button in y-axis

### DIFF
--- a/src/components/ExperienceTable/ExperienceTable.tsx
+++ b/src/components/ExperienceTable/ExperienceTable.tsx
@@ -45,7 +45,7 @@ export const ExperienceTable = ({
   const categorizedRows = rows.filter((row) => row.subrows);
 
   return (
-    <div className="overflow-x-auto pl-3">
+    <div className="overflow-x-auto pl-3 pt-3">
       {rows.length > 0 && (
         <table className="w-full" border={0} cellPadding={0} cellSpacing={0}>
           <thead className="after:content-[''] after:block after:h-5">


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add `padding-top` for the container for not to clip outline of the button when there is no rows in table

## Notes

Tried to check if there is some other solution for these paddings, but on the other end did not use too much time as it is good for now. Before hopefully getting the overhaul for the menu moving from side to the content area's top part with narrower screen sizes.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1297
https://jira.eduuni.fi/browse/OPHJOD-1277 (where these `pl-3 pt-3` could be removed )
