### PR TITLE
OPHJOD-1234: Remove cache invalidation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,3 @@ jobs:
         run: |
           aws s3 sync --size-only --delete --cache-control "public,max-age=31536000,immutable" assets/ s3://${{ secrets.JOD_AWS_DIST_BUCKET }}/yksilo/assets
           aws s3 sync --exclude "assets/*" --delete --cache-control "public,max-age=0,s-maxage=60,must-revalidate" . s3://${{ secrets.JOD_AWS_DIST_BUCKET }}/yksilo
-
-      - name: Invalidate cache for index.html on deploy
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.JOD_AWS_CLOUDFRONT_ID }} --paths '/yksilo/index.html'


### PR DESCRIPTION
## Description
Remove cache invalidation from deploy (due to account change, no access to distribution). Should not cause issues, index.html is cached only in CF and up to 60 seconds.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1234
