### PR TITLE
OPHJOD-1353: Add support for hierarchical checkbox states in ExperienceTable

### DIFF
--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -34,6 +34,9 @@ interface ExperienceTableRowProps {
   confirmDescription?: string;
   actionLabel?: string;
   showCheckbox?: boolean;
+  checked?: boolean;
+  indeterminate?: boolean;
+  onCheckboxChange?: (checked: boolean) => void;
 }
 
 const Title = ({ nested, row }: { nested?: boolean; row: ExperienceTableRowData }) => {
@@ -63,6 +66,9 @@ export const ExperienceTableRow = ({
   confirmDescription,
   actionLabel,
   showCheckbox,
+  checked,
+  indeterminate,
+  onCheckboxChange,
 }: ExperienceTableRowProps) => {
   const {
     t,
@@ -122,10 +128,15 @@ export const ExperienceTableRow = ({
       <Checkbox
         name={`checkbox-${row.key}`}
         value={row.key}
-        checked={row?.checked ?? true}
+        checked={checked !== undefined ? checked : (row?.checked ?? false)}
+        indeterminate={indeterminate}
         onChange={(e) => {
-          row.checked = e.target.checked;
-          setIsOpen((prev) => !prev); // Ensure state rerenders
+          if (onCheckboxChange) {
+            onCheckboxChange(e.target.checked);
+          } else {
+            row.checked = e.target.checked;
+            setIsOpen((prev) => !prev); // Ensure state rerenders
+          }
         }}
         ariaLabel={t('choose') + ' ' + row.nimi[language]}
         variant="bordered"


### PR DESCRIPTION
## Description

Implemented parent-child checkbox functionality for hierarchical data within the `ExperienceTable`. Added indeterminate states to reflect partial selections. Synchronization ensures the parent checkbox reflects the state of its child rows and vice versa. Callback functions were updated to handle state changes, enhancing table usability and state management.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1353