### PR TITLE
OPHJOD-1377: Fix build issues and refactor get localization logic

### DIFF
--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -40,16 +40,12 @@ interface ExperienceTableRowProps {
 }
 
 const Title = ({ nested, row }: { nested?: boolean; row: ExperienceTableRowData }) => {
-  const { i18n } = useTranslation();
+  const text = getLocalizedText(row?.nimi);
 
   return nested ? (
-    <p className="pl-5 pr-7 pt-2 text-body-sm font-bold sm:font-normal sm:text-body-md sm:py-2 hyphens-auto">
-      {row?.nimi[i18n.language]}
-    </p>
+    <p className="pl-5 pr-7 pt-2 text-body-sm font-bold sm:font-normal sm:text-body-md sm:py-2 hyphens-auto">{text}</p>
   ) : (
-    <p className="pl-5 pr-7 pt-2 text-heading-4 sm:text-heading-3 sm:pt-1 sm:pb-[3px] hyphens-auto">
-      {row?.nimi[i18n.language]}
-    </p>
+    <p className="pl-5 pr-7 pt-2 text-heading-4 sm:text-heading-3 sm:pt-1 sm:pb-[3px] hyphens-auto">{text}</p>
   );
 };
 

--- a/src/routes/JobOpportunity/JobOpportunity.tsx
+++ b/src/routes/JobOpportunity/JobOpportunity.tsx
@@ -26,7 +26,7 @@ const JobOpportunity = () => {
     getLocalizedText(tyomahdollisuus?.tehtavat) !== ''
       ? getLocalizedText(tyomahdollisuus?.tehtavat)
           .split('\n')
-          .sort((a, b) => a.localeCompare(b))
+          .sort((a: string, b: string) => a.localeCompare(b))
       : [];
 
   const sections: OpportunityDetailsSection[] = [
@@ -38,7 +38,7 @@ const JobOpportunity = () => {
       navTitle: t('job-opportunity.most-common-job-tasks.title'),
       content: (
         <ol className="list-decimal ml-7 text-body-lg font-medium text-black leading-7">
-          {tyomahdollisuusTehtavat.map((value, index) => (
+          {tyomahdollisuusTehtavat.map((value: string, index: number) => (
             // eslint-disable-next-line react/no-array-index-key
             <li key={`${hashString(value)}-${index}`} className="text-capitalize text-body">
               {value}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,7 +19,12 @@ export const formatDate = (date: Date) => {
 export const getLocalizedText = (
   entry?: components['schemas']['LokalisoituTeksti'] | Record<string, string | undefined>,
   lang = i18n.language,
-) => entry?.[lang] ?? '';
+) =>
+  entry?.[lang] ??
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  entry?.[i18n.options.fallbackLng] ??
+  '';
 
 type NestedKeyOf<ObjectType extends object> = {
   [Key in keyof ObjectType & (string | number)]: ObjectType[Key] extends object


### PR DESCRIPTION
## Description

When there is missing translation for get localized text with current language, fallback to get localized text with default language which is defined in src/i18n/config.ts.

Note! Uncommented the "fallbackLng: defaultLang" line in `config.ts` to enable testing of the fallback language changes.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1377