### PR TITLE
OPHJOD-1301: Fix suosikit not updating properly when entering päämääräni page

### DIFF
--- a/src/api/mahdollisuusService.ts
+++ b/src/api/mahdollisuusService.ts
@@ -1,0 +1,38 @@
+import { client } from '@/api/client';
+
+export const getTyoMahdollisuusDetails = async (ids: string[]) => {
+  if (ids.length === 0) {
+    return [];
+  }
+  const { data, error } = await client.GET('/api/tyomahdollisuudet', {
+    params: {
+      query: {
+        id: ids,
+      },
+    },
+  });
+
+  if (!error) {
+    return data?.sisalto ?? [];
+  }
+
+  return [];
+};
+
+export const getKoulutusMahdollisuusDetails = async (ids: string[]) => {
+  if (ids.length === 0) {
+    return [];
+  }
+  const { data, error } = await client.GET('/api/koulutusmahdollisuudet', {
+    params: {
+      query: {
+        id: ids,
+      },
+    },
+  });
+
+  if (!error) {
+    return data?.sisalto ?? [];
+  }
+  return [];
+};

--- a/src/routes/Profile/MyGoals/MyGoals.tsx
+++ b/src/routes/Profile/MyGoals/MyGoals.tsx
@@ -6,8 +6,7 @@ import { Button } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdArrowForward } from 'react-icons/md';
-import { Link, useOutletContext, useRevalidator } from 'react-router';
-import { useShallow } from 'zustand/shallow';
+import { Link, useOutletContext } from 'react-router';
 import AddGoalModal from './AddGoalModal';
 import MyGoalsSection from './MyGoalsSection';
 
@@ -46,20 +45,19 @@ const MyGoals = () => {
   const navigationRoutes = React.useMemo(() => mapNavigationRoutes(routes), [routes]);
   const title = t('profile.my-goals.title');
   const [addModalOpen, setAddModalOpen] = React.useState(false);
-  const revalidator = useRevalidator();
   const suosikitIsEmpty = useSuosikitStore((state) => state.suosikit).length === 0;
-  const { pitkanAikavalinTavoite, lyhyenAikavalinTavoite, muutTavoitteet } = usePaamaaratStore(
-    useShallow((state) => ({
-      pitkanAikavalinTavoite: state.pitkanAikavalinTavoite,
-      lyhyenAikavalinTavoite: state.lyhyenAikavalinTavoite,
-      muutTavoitteet: state.muutTavoitteet,
-    })),
-  );
+  const paamaarat = usePaamaaratStore((state) => state.paamaarat);
+
+  const { pitkanAikavalinTavoite, lyhyenAikavalinTavoite, muutTavoitteet } = React.useMemo(() => {
+    return {
+      pitkanAikavalinTavoite: paamaarat.filter((p) => p.tyyppi === 'PITKA'),
+      lyhyenAikavalinTavoite: paamaarat.filter((p) => p.tyyppi === 'LYHYT'),
+      muutTavoitteet: paamaarat.filter((p) => p.tyyppi === 'MUU'),
+    };
+  }, [paamaarat]);
 
   const onCloseAddModal = () => {
     setAddModalOpen(false);
-    // Fetch the data again to update the goals
-    revalidator.revalidate();
   };
 
   return (

--- a/src/routes/Profile/MyGoals/MyGoalsSection.tsx
+++ b/src/routes/Profile/MyGoals/MyGoalsSection.tsx
@@ -2,14 +2,13 @@ import { components } from '@/api/schema';
 import { OpportunityCard } from '@/components';
 import DeletePolkuButton from '@/components/DeletePolkuButton/DeletePolkuButton';
 import { getTypeSlug } from '@/routes/Profile/utils';
-import { MahdollisuusTyyppi } from '@/routes/types';
+import { usePaamaaratStore } from '@/stores/usePaamaratStore';
 import { getLocalizedText } from '@/utils';
 import { Button } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdArrowForward } from 'react-icons/md';
-import { Link, useLoaderData } from 'react-router';
-import loader from './loader';
+import { Link } from 'react-router';
 import MyGoalsOpportunityCardMenu from './MyGoalsOpportunityCardMenu';
 import TavoiteInput from './TavoiteInput';
 
@@ -24,40 +23,12 @@ const MyGoalsSection = ({ title, description, icon, paamaarat }: MyGoalsSectionP
     t,
     i18n: { language },
   } = useTranslation();
-  const { koulutusMahdollisuudetDetails, tyomahdollisuudetDetails } =
-    useLoaderData<Awaited<ReturnType<typeof loader>>>();
+  const mahdollisuusDetails = usePaamaaratStore((state) => state.mahdollisuusDetails);
 
-  // Use a local state for paamaarat to be able to remove suunnitelmat from it without reloading the page
-  const [goals, setGoals] = React.useState<components['schemas']['PaamaaraDto'][]>(paamaarat);
-
-  const getDetailsByTyyppi = React.useCallback(
-    (tyyppi: MahdollisuusTyyppi, id: string) => {
-      switch (tyyppi) {
-        case 'KOULUTUSMAHDOLLISUUS':
-          return koulutusMahdollisuudetDetails.find((koulutus) => koulutus.id === id);
-        case 'TYOMAHDOLLISUUS':
-          return tyomahdollisuudetDetails.find((tyo) => tyo.id === id);
-      }
-    },
-    [koulutusMahdollisuudetDetails, tyomahdollisuudetDetails],
+  const getMahdollisuusDetails = React.useCallback(
+    (id: string) => mahdollisuusDetails.find((item) => item.id === id),
+    [mahdollisuusDetails],
   );
-
-  const removePolku = (paamaaraId?: string, suunnitelmaId?: string) => {
-    if (paamaaraId && suunnitelmaId) {
-      setGoals((prev) =>
-        prev.map((pm) => {
-          if (pm.id === paamaaraId) {
-            return {
-              ...pm,
-              // eslint-disable-next-line sonarjs/no-nested-functions
-              suunnitelmat: pm.suunnitelmat?.filter((s) => s.id !== suunnitelmaId),
-            };
-          }
-          return pm;
-        }),
-      );
-    }
-  };
 
   return (
     <div className="mb-5">
@@ -67,12 +38,12 @@ const MyGoalsSection = ({ title, description, icon, paamaarat }: MyGoalsSectionP
       </div>
       <p className={`${icon ? 'ml-8' : ''} text-body-lg font-medium mb-5`}>{description}</p>
       <div className="flex flex-col gap-5 mb-5">
-        {goals.map((pm, i) => {
+        {paamaarat.map((pm, i) => {
           const { mahdollisuusId, mahdollisuusTyyppi, id } = pm;
-          const details = getDetailsByTyyppi(mahdollisuusTyyppi, mahdollisuusId);
+          const details = getMahdollisuusDetails(mahdollisuusId);
           const menuId = id ?? `menu-${i}`;
           return details ? (
-            <div key={mahdollisuusId} className="flex flex-col gap-5 mb-9">
+            <div key={pm.id ?? mahdollisuusId} className="flex flex-col gap-5 mb-9">
               <OpportunityCard
                 to={`/${language}/${getTypeSlug(mahdollisuusTyyppi)}/${mahdollisuusId}`}
                 description={getLocalizedText(details?.tiivistelma)}
@@ -105,11 +76,7 @@ const MyGoalsSection = ({ title, description, icon, paamaarat }: MyGoalsSectionP
                     >
                       {polku.nimi[language]} <MdArrowForward size={24} />
                     </Link>
-                    <DeletePolkuButton
-                      paamaaraId={pm.id}
-                      suunnitelmaId={polku.id}
-                      onDelete={() => removePolku(pm.id, polku.id)}
-                    />
+                    <DeletePolkuButton paamaaraId={pm.id} suunnitelmaId={polku.id} />
                   </div>
                 ))}
                 <div className="mt-9">

--- a/src/routes/Profile/MyGoals/utils.ts
+++ b/src/routes/Profile/MyGoals/utils.ts
@@ -9,7 +9,11 @@ export type PaamaaraTyyppi = components['schemas']['PaamaaraDto']['tyyppi'];
  * @returns The goal type of the opportunity
  */
 export const getPaamaaraTypeForMahdollisuus = (mahdollisuusId: string): PaamaaraTyyppi | undefined => {
-  const { pitkanAikavalinTavoite, lyhyenAikavalinTavoite, muutTavoitteet } = usePaamaaratStore.getState();
+  const { paamaarat } = usePaamaaratStore.getState();
+  const pitkanAikavalinTavoite = paamaarat.filter((p) => p.tyyppi === 'PITKA');
+  const lyhyenAikavalinTavoite = paamaarat.filter((p) => p.tyyppi === 'LYHYT');
+  const muutTavoitteet = paamaarat.filter((p) => p.tyyppi === 'MUU');
+
   if (pitkanAikavalinTavoite.find((tavoite) => tavoite.mahdollisuusId === mahdollisuusId)) {
     return 'PITKA';
   } else if (lyhyenAikavalinTavoite.find((tavoite) => tavoite.mahdollisuusId === mahdollisuusId)) {

--- a/src/stores/usePaamaratStore/index.ts
+++ b/src/stores/usePaamaratStore/index.ts
@@ -1,45 +1,48 @@
+import { client } from '@/api/client';
 import { components } from '@/api/schema';
+import { TypedMahdollisuus } from '@/routes/types';
 import { create } from 'zustand';
 
 type Paamaara = components['schemas']['PaamaaraDto'];
 
 interface PaamaaratState {
-  pitkanAikavalinTavoite: Paamaara[];
-  lyhyenAikavalinTavoite: Paamaara[];
-  muutTavoitteet: Paamaara[];
   paamaarat: Paamaara[];
-
-  setPitkanAikavalinTavoite: (state: Paamaara[]) => void;
-  setLyhyenAikavalinTavoite: (state: Paamaara[]) => void;
-  setMuutTavoitteet: (state: Paamaara[]) => void;
   setPaamaarat: (state: Paamaara[]) => void;
   upsertPaamaara: (paamaara: Paamaara) => void;
-  updateCategories: () => void;
+  deletePaamaara: (paamaaraId: string) => Promise<void>;
+  mahdollisuusDetails: TypedMahdollisuus[];
+  setMahdollisuusDetails: (state: TypedMahdollisuus[]) => void;
 }
 
 export const usePaamaaratStore = create<PaamaaratState>()((set, get) => ({
-  pitkanAikavalinTavoite: [],
-  lyhyenAikavalinTavoite: [],
-  muutTavoitteet: [],
   paamaarat: [],
-  setPitkanAikavalinTavoite: (state) => set({ pitkanAikavalinTavoite: state }),
-  setLyhyenAikavalinTavoite: (state) => set({ lyhyenAikavalinTavoite: state }),
-  setMuutTavoitteet: (state) => set({ muutTavoitteet: state }),
+  mahdollisuusDetails: [],
+
+  setMahdollisuusDetails: (state) => set({ mahdollisuusDetails: state }),
+
   setPaamaarat: (state) => set({ paamaarat: state }),
-  updateCategories: () => {
-    const { paamaarat } = get();
-    get().setPitkanAikavalinTavoite(paamaarat.filter((paamaara) => paamaara.tyyppi === 'PITKA'));
-    get().setLyhyenAikavalinTavoite(paamaarat.filter((paamaara) => paamaara.tyyppi === 'LYHYT'));
-    get().setMuutTavoitteet(paamaarat.filter((paamaara) => paamaara.tyyppi === 'MUU'));
-  },
   upsertPaamaara: (paamaara) => {
-    const { updateCategories } = get();
-    set((state) => ({
-      ...state,
-      paamaarat: state.paamaarat.find((pm) => pm.mahdollisuusId === paamaara.mahdollisuusId)
-        ? [...state.paamaarat.map((pm) => (pm.mahdollisuusId === paamaara.mahdollisuusId ? paamaara : pm))]
-        : [...state.paamaarat, paamaara],
-    }));
-    updateCategories();
+    set((state) => {
+      const exists = state.paamaarat.some((pm) => pm.mahdollisuusId === paamaara.mahdollisuusId);
+
+      return {
+        paamaarat: exists
+          ? state.paamaarat.map((pm) => (pm.mahdollisuusId === paamaara.mahdollisuusId ? { ...paamaara } : pm))
+          : [...state.paamaarat, { ...paamaara }],
+      };
+    });
+  },
+  deletePaamaara: async (id: string) => {
+    const { error } = await client.DELETE('/api/profiili/paamaarat/{id}', {
+      params: {
+        path: { id },
+      },
+    });
+
+    if (!error) {
+      set({
+        paamaarat: get().paamaarat.filter((pm) => pm.id !== id),
+      });
+    }
   },
 }));


### PR DESCRIPTION
## Description

* Remove the usage of `reavalidator.revalidate()` to prevent reloading data from API just to update the UI, use local state more efficiently instead
* Suosikit should now update from API every time user navigates to päämääräni page
* Mahdollisuus details are now stored to paamaaraStore and used from there. This allows the details fetched in "AddGoalModal" to be used in "MyGoalsSection" without the need to refetch them.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1301
