### PR TITLE
OPHJOD-1306: Implement UI feedback for competence status in education import

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -745,6 +745,9 @@ export interface components {
       /** Format: date */
       loppuPvm?: string;
       osaamiset?: string[];
+      osaamisetOdottaaTunnistusta?: boolean;
+      osaamisetTunnistusEpaonnistui?: boolean;
+      osasuoritukset?: string[];
     };
     ToimintoDto: {
       /** Format: uuid */

--- a/src/components/ExperienceTable/ExperienceTable.tsx
+++ b/src/components/ExperienceTable/ExperienceTable.tsx
@@ -196,6 +196,8 @@ export const ExperienceTable = ({
                   onRowClick={onRowClick}
                   className="bg-white border-spacing-x-2"
                   hideOsaamiset={hideOsaamiset}
+                  osaamisetOdottaaTunnistusta={row.osaamisetOdottaaTunnistusta}
+                  osaamisetTunnistusEpaonnistui={row.osaamisetTunnistusEpaonnistui}
                   rowActionElement={rowActionElement}
                   useConfirm={useConfirm}
                   confirmTitle={confirmTitle}
@@ -215,6 +217,8 @@ export const ExperienceTable = ({
                     className={i % 2 !== 0 ? 'bg-white bg-opacity-60' : 'bg-bg-gray'}
                     nested
                     hideOsaamiset={hideOsaamiset}
+                    osaamisetOdottaaTunnistusta={subrow.osaamisetOdottaaTunnistusta}
+                    osaamisetTunnistusEpaonnistui={subrow.osaamisetTunnistusEpaonnistui}
                     rowActionElement={rowActionElement}
                     useConfirm={useConfirm}
                     confirmTitle={confirmTitle}
@@ -256,6 +260,8 @@ export const ExperienceTable = ({
                 row={row}
                 onRowClick={onRowClick}
                 hideOsaamiset={hideOsaamiset}
+                osaamisetOdottaaTunnistusta={row.osaamisetOdottaaTunnistusta}
+                osaamisetTunnistusEpaonnistui={row.osaamisetTunnistusEpaonnistui}
                 rowActionElement={rowActionElement}
                 useConfirm={useConfirm}
                 confirmTitle={confirmTitle}

--- a/src/components/Tooltip/TooltipWrapper.tsx
+++ b/src/components/Tooltip/TooltipWrapper.tsx
@@ -1,0 +1,35 @@
+import { Tooltip, TooltipContent, TooltipTrigger, useMediaQueries } from '@jod/design-system';
+import React from 'react';
+
+export const TooltipWrapper = ({
+  children,
+  tooltipOpen,
+  tooltipContent,
+  tooltipPlacement = 'bottom',
+  halfWidth = false,
+}: {
+  children: React.ReactNode;
+  tooltipContent: React.ReactNode;
+  tooltipOpen?: boolean;
+  tooltipPlacement?: React.ComponentProps<typeof Tooltip>['placement'];
+  halfWidth?: boolean;
+}) => {
+  const { sm } = useMediaQueries();
+  let sizeClassName = '';
+  if (halfWidth) {
+    sizeClassName = sm ? ' w-1/2' : 'max-w-fit mr-11';
+  }
+
+  return (
+    <Tooltip open={tooltipOpen} placement={tooltipPlacement}>
+      <TooltipContent
+        className={`bg-black text-white rounded-xl p-5 z-50 text-body-sm sm:text-body-md font-arial ${sizeClassName}`}
+      >
+        {tooltipContent}
+      </TooltipContent>
+      <TooltipTrigger asChild>
+        <div>{children}</div>
+      </TooltipTrigger>
+    </Tooltip>
+  );
+};

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -1,4 +1,5 @@
 {
+  "about-ai": "Tietoa tekoälyn käytöstä",
   "about-us": "Tietoa meistä",
   "about-us-and-user-guide": "Tietoa palvelusta ja käyttöohjeet",
   "accept": "Hyväksy",
@@ -17,6 +18,8 @@
   "competence": "Osaaminen",
   "competences": "Osaamiset",
   "competences-from-profile": "Osaamisprofiilista tuotu osaamiseni",
+  "competences-identify-failed": "Tekoälyn osaamistunnistus epäonnistui.",
+  "competences-identifying": "Voit muokata koulutusta, kun osaamiset ovat latautuneet.",
   "competences-of-your-choice": "Valitut osaamiset",
   "content": "Sisältö",
   "cookie-policy": "Evästekäytäntö",
@@ -76,7 +79,9 @@
     "result-modal": {
       "failure": "Koulutus historia lisääminen epäonnistui.",
       "give-permission-failed": "Luvan antaminen epäonnistui. Yritä myöhemmin uudelleen.",
-      "success": "Koulutus historia lisätty onnistuneesti."
+      "success": "Koulutus historia lisätty onnistuneesti.",
+      "success-osaamiset-info": "Seuraavaksi tunnistamme sinulle lisättyihin koulutuksiin osaamisia.\nVoit poistaa ja lisätä osaamisia muokkaamalla koulutuksen tietoja.\nLisätietoja osaamisten tunnistamisesta löydät alla olevasta linkistä.",
+      "success-osaamiset-link-about-ai": "Tietoa tekoälyn käytöstä"
     },
     "start-modal": {
       "description": "Voit tuoda koulutushistoriasi palveluun, kun olet antanut luvan Opintopolussa. Paina \"Siirry Opintopolkuun\", niin voit myöntää luvan tietojen tuontiin. Luvan antamisen jälkeen palaat automaattisesti takaisin palveluun.",
@@ -545,6 +550,7 @@
     "main": "Siirry pääsisältöön"
   },
   "slugs": {
+    "about-ai": "tietoa-tekoalysta",
     "about-us": "tietoa-palvelusta",
     "accessibility-statement": "saavutettavuusseloste",
     "basic-information": "perustiedot",

--- a/src/routes/BasicInformation/AboutAi.tsx
+++ b/src/routes/BasicInformation/AboutAi.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+
+const AboutAi = () => {
+  const { t } = useTranslation();
+  const title = t('about-ai');
+
+  return (
+    <>
+      <title>{title}</title>
+      <h1 className="mb-5 text-heading-2 sm:text-heading-1">{title}</h1>
+      <p className="mb-8 text-body-md font-arial text-todo">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisi. Integer vehicula risus et dignissim
+        ultricies. Proin ut eros sit amet quam pulvinar consequat nec sit amet mauris. Phasellus at turpis quis ligula
+        convallis scelerisque.
+      </p>
+    </>
+  );
+};
+
+export default AboutAi;

--- a/src/routes/BasicInformation/BasicInformation.tsx
+++ b/src/routes/BasicInformation/BasicInformation.tsx
@@ -25,6 +25,10 @@ const BasicInformation = () => {
       name: t('privacy-policy'),
       path: t('slugs.privacy-policy'),
     },
+    {
+      name: t('about-ai'),
+      path: t('slugs.about-ai'),
+    },
   ];
 
   return (

--- a/src/routes/BasicInformation/index.ts
+++ b/src/routes/BasicInformation/index.ts
@@ -1,3 +1,4 @@
+import AboutAi from './AboutAi';
 import AccessibilityStatement from './AccessibilityStatement';
 import BasicInformation from './BasicInformation';
 import CookiePolicy from './CookiePolicy';
@@ -5,4 +6,4 @@ import DataSources from './DataSources';
 import PrivacyPolicy from './PrivacyPolicy';
 import TermsOfService from './TermsOfService';
 
-export { AccessibilityStatement, BasicInformation, CookiePolicy, DataSources, PrivacyPolicy, TermsOfService };
+export { AboutAi, AccessibilityStatement, BasicInformation, CookiePolicy, DataSources, PrivacyPolicy, TermsOfService };

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -6,17 +6,18 @@ import {
   type ExperienceTableRowData,
   type RoutesNavigationListProps,
 } from '@/components';
+import { TooltipWrapper } from '@/components/Tooltip/TooltipWrapper';
 import { EducationHistoryWizard } from '@/routes/Profile/EducationHistory/EducationHistoryWizard';
 import EditKoulutuskokonaisuusModal from '@/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal';
-import ImportKoulutusSummaryModal from '@/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx';
+import ImportKoulutusSummaryModal from '@/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal';
 import { Button } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoaderData, useOutletContext, useRevalidator, useSearchParams } from 'react-router';
 import { mapNavigationRoutes } from '../utils';
 import AddOrEditKoulutusModal from './modals/AddOrEditKoulutusModal';
-import ImportKoulutusResultModal from './modals/ImportKoulutusResultModal.tsx';
-import ImportKoulutusStartModal from './modals/ImportKoulutusStartModal.tsx';
+import ImportKoulutusResultModal from './modals/ImportKoulutusResultModal';
+import ImportKoulutusStartModal from './modals/ImportKoulutusStartModal';
 import { getEducationHistoryTableRows, Koulutuskokonaisuus } from './utils';
 
 const EducationHistory = () => {
@@ -51,9 +52,18 @@ const EducationHistory = () => {
   const [isImportSuccess, setIsImportSuccess] = React.useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const [isOsaamisetIdentifyOngoing, setIsOsaamisetIdentifyOngoing] = React.useState(true);
+
   React.useEffect(() => {
     setRows(getEducationHistoryTableRows(koulutuskokonaisuudet, osaamisetMap));
   }, [koulutuskokonaisuudet, osaamisetMap]);
+
+  React.useEffect(() => {
+    const isIdentifyingCompetence = rows.some(
+      (row) => row.osaamisetOdottaaTunnistusta || row.subrows?.some((subRow) => subRow.osaamisetOdottaaTunnistusta),
+    );
+    setIsOsaamisetIdentifyOngoing(isIdentifyingCompetence);
+  }, [rows]);
 
   const onRowClick = (row: ExperienceTableRowData) => {
     setKoulutuskokonaisuusId(row.key);
@@ -115,6 +125,7 @@ const EducationHistory = () => {
 
   const closeImportResultModal = () => {
     setIsImportResultModalOpen(false);
+    revalidator.revalidate();
   };
 
   React.useEffect(() => {
@@ -158,11 +169,18 @@ const EducationHistory = () => {
           />
         </div>
         <div>
-          <Button
-            variant="white"
-            label={t('education-history.import-education-history')}
-            onClick={openImportStartModal}
-          />
+          <TooltipWrapper
+            tooltipPlacement="top"
+            tooltipContent={t('competences-identifying')}
+            tooltipOpen={isOsaamisetIdentifyOngoing ? undefined : false}
+          >
+            <Button
+              variant="white"
+              label={t('education-history.import-education-history')}
+              onClick={openImportStartModal}
+              disabled={isOsaamisetIdentifyOngoing}
+            />
+          </TooltipWrapper>
         </div>
       </div>
       {isKoulutuskokonaisuusOpen && koulutuskokonaisuusId && (

--- a/src/routes/Profile/EducationHistory/modals/ImportKoulutusResultModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoulutusResultModal.tsx
@@ -2,7 +2,8 @@ import { useEscHandler } from '@/hooks/useEscHandler';
 import { Button, Modal } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { MdCheckCircleOutline, MdClear } from 'react-icons/md';
+import { MdArrowForward, MdCheckCircleOutline, MdClear } from 'react-icons/md';
+import { Link } from 'react-router';
 
 interface ImportKoulutusResultModalProps {
   isOpen: boolean;
@@ -12,7 +13,10 @@ interface ImportKoulutusResultModalProps {
 }
 
 const ImportKoulutusResultModal = ({ isOpen, onClose, isSuccess, errorText }: ImportKoulutusResultModalProps) => {
-  const { t } = useTranslation();
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
 
   const modalId = React.useId();
   useEscHandler(onClose, modalId);
@@ -31,13 +35,29 @@ const ImportKoulutusResultModal = ({ isOpen, onClose, isSuccess, errorText }: Im
         >
           <div className="flex flex-col items-center pointer-events-auto">
             {isSuccess ? (
-              <>
-                <MdCheckCircleOutline className="text-heading-1 text-success" />
-                <h3 className="mb-5 text-heading-2">{t('education-history-import.result-modal.success')}</h3>
-              </>
+              <div className="flex flex-col items-start w-full">
+                <div className="w-full flex justify-center mb-4">
+                  <MdCheckCircleOutline className="text-heading-1 text-success" />
+                </div>
+                <div className="mx-8 w-full flex flex-col">
+                  <div className="text-heading-2">{t('education-history-import.result-modal.success')}</div>
+                  <p className="max-w-full break-words whitespace-pre-line">
+                    {t('education-history-import.result-modal.success-osaamiset-info')}
+                  </p>
+                  <Link
+                    to={`/${language}/${t('slugs.basic-information')}/${t('slugs.about-ai')}`}
+                    className="text-button-md hover:underline text-accent mt-4"
+                  >
+                    <div className="flex items-center gap-2">
+                      {t('education-history-import.result-modal.success-osaamiset-link-about-ai')}
+                      <MdArrowForward size={24} />
+                    </div>
+                  </Link>
+                </div>
+              </div>
             ) : (
               <>
-                <MdClear className="text-heading-1 text-alert-text" />
+                <MdClear className="text-heading-1 text-alert-text mb-4" />
                 <h3 className="mb-5 text-heading-2">
                   {errorText ?? t('education-history-import.result-modal.failure')}
                 </h3>

--- a/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
@@ -100,17 +100,14 @@ const ImportKoulutusSummaryModal = ({ isOpen, onClose, onSuccessful, onFailure }
     alkuPvm: data.alkuPvm,
     loppuPvm: data.loppuPvm,
     osaamiset: [],
+    osasuoritukset: data.osasuoritukset,
   });
 
   const isChecked = (
     key: string,
     data: {
-      id?: string;
       nimi: components['schemas']['LokalisoituTeksti'];
       kuvaus?: components['schemas']['LokalisoituTeksti'];
-      alkuPvm?: string;
-      loppuPvm?: string;
-      osaamiset?: string[];
     },
   ) => {
     const matchSchool = tableRows?.find((row) => JSON.stringify(row.nimi) === key);
@@ -215,11 +212,6 @@ const ImportKoulutusSummaryModal = ({ isOpen, onClose, onSuccessful, onFailure }
               />
             )}
           </div>
-          {!isFetching && !error && (
-            <div className="sticky p-4 bottom-0 bg-bg-gray w-full text-todo">
-              Tähän kuvaus, että osaamisia lisätty opintoihin. TODO: OPHJOD-1306
-            </div>
-          )}
         </div>
       }
       footer={

--- a/src/routes/Profile/EducationHistory/utils.ts
+++ b/src/routes/Profile/EducationHistory/utils.ts
@@ -7,6 +7,9 @@ export interface Koulutus {
   alkuPvm?: string;
   loppuPvm?: string;
   osaamiset: string[];
+  osaamisetOdottaaTunnistusta?: boolean;
+  osaamisetTunnistusEpaonnistui?: boolean;
+  osasuoritukset?: string[];
 }
 
 export interface Koulutuskokonaisuus {
@@ -59,6 +62,8 @@ export const getEducationHistoryTableRows = (
         sourceType: 'koulutus',
       })),
       checked: true,
+      osaamisetOdottaaTunnistusta: row.koulutukset.some((koulutus) => koulutus.osaamisetOdottaaTunnistusta),
+      osaamisetTunnistusEpaonnistui: row.koulutukset.some((koulutus) => koulutus.osaamisetTunnistusEpaonnistui),
     };
 
     rows.push(rowData);
@@ -86,4 +91,6 @@ const mapKoulutusToRow = (
     sourceType: 'koulutus',
   })),
   checked: true,
+  osaamisetOdottaaTunnistusta: koulutus.osaamisetOdottaaTunnistusta,
+  osaamisetTunnistusEpaonnistui: koulutus.osaamisetTunnistusEpaonnistui,
 });

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -44,6 +44,7 @@ const Root = () => {
     NavigationBarItem(`${basicInformation}/${t('slugs.terms-of-service')}`, t('terms-of-service')),
     NavigationBarItem(`${basicInformation}/${t('slugs.accessibility-statement')}`, t('accessibility-statement')),
     NavigationBarItem(`${basicInformation}/${t('slugs.privacy-policy')}`, t('privacy-policy')),
+    NavigationBarItem(`${basicInformation}/${t('slugs.about-ai')}`, t('about-ai')),
   ];
   const logoutForm = React.useRef<HTMLFormElement>(null);
   const megaMenuButtonRef = React.useRef<HTMLButtonElement>(null);

--- a/src/routes/Tool/Goals.tsx
+++ b/src/routes/Tool/Goals.tsx
@@ -1,5 +1,6 @@
+import { TooltipWrapper } from '@/components/Tooltip/TooltipWrapper';
 import { useToolStore } from '@/stores/useToolStore';
-import { SelectionCard, Tooltip, TooltipContent, TooltipTrigger, useMediaQueries } from '@jod/design-system';
+import { SelectionCard, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdInfoOutline } from 'react-icons/md';
@@ -267,30 +268,6 @@ const InfoButton = ({ ariaLabel, onClick }: { ariaLabel: string; onClick: () => 
   );
 };
 
-const TooltipWrapper = ({
-  children,
-  tooltipOpen,
-  tooltipContent,
-}: {
-  children: React.ReactNode;
-  tooltipContent: React.ReactNode;
-  tooltipOpen: boolean;
-}) => {
-  const { sm } = useMediaQueries();
-  return (
-    <Tooltip open={tooltipOpen} placement="bottom">
-      <TooltipContent
-        className={`bg-black text-white rounded-xl p-5 z-50 text-body-sm sm:text-body-md font-arial ${sm ? 'w-1/2' : 'max-w-fit mr-11'}`}
-      >
-        {tooltipContent}
-      </TooltipContent>
-      <TooltipTrigger asChild>
-        <div>{children}</div>
-      </TooltipTrigger>
-    </Tooltip>
-  );
-};
-
 const Goals = () => {
   const { t } = useTranslation();
   const toolStore = useToolStore();
@@ -351,6 +328,7 @@ const Goals = () => {
         <TooltipWrapper
           tooltipOpen={openTooltips.mapCompetence}
           tooltipContent={t('tool.my-own-data.goals.map-competence-tooltip')}
+          halfWidth
         >
           <SelectionCard
             actionComponent={<InfoButton ariaLabel="info" onClick={toggleTooltip('mapCompetence')} />}
@@ -366,6 +344,7 @@ const Goals = () => {
         <TooltipWrapper
           tooltipOpen={openTooltips.trainings}
           tooltipContent={t('tool.my-own-data.goals.trainings-tooltip')}
+          halfWidth
         >
           <SelectionCard
             actionComponent={<InfoButton ariaLabel="info" onClick={toggleTooltip('trainings')} />}
@@ -381,6 +360,7 @@ const Goals = () => {
         <TooltipWrapper
           tooltipOpen={openTooltips.jobOpportunities}
           tooltipContent={t('tool.my-own-data.goals.job-opportunities-tooltip')}
+          halfWidth
         >
           <SelectionCard
             actionComponent={<InfoButton ariaLabel="info" onClick={toggleTooltip('jobOpportunities')} />}
@@ -396,6 +376,7 @@ const Goals = () => {
         <TooltipWrapper
           tooltipOpen={openTooltips.mapOpportunities}
           tooltipContent={t('tool.my-own-data.goals.map-opportunities-tooltip')}
+          halfWidth
         >
           <SelectionCard
             actionComponent={<InfoButton ariaLabel="info" onClick={toggleTooltip('mapOpportunities')} />}
@@ -411,6 +392,7 @@ const Goals = () => {
         <TooltipWrapper
           tooltipOpen={openTooltips.somethingElse}
           tooltipContent={t('tool.my-own-data.goals.something-else-tooltip')}
+          halfWidth
         >
           <SelectionCard
             actionComponent={<InfoButton ariaLabel="info" onClick={toggleTooltip('somethingElse')} />}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,6 +21,7 @@ import {
 import { RouteObject, replace } from 'react-router';
 import { withYksiloContext } from '../auth';
 import {
+  AboutAi,
   AccessibilityStatement,
   BasicInformation,
   CookiePolicy,
@@ -267,6 +268,11 @@ const basicInformationRoutes: RouteObject[] = supportedLanguageCodes.map((lng) =
       id: `{slugs.privacy-policy}|${lng}`,
       path: i18n.t('slugs.privacy-policy', { lng }),
       element: <PrivacyPolicy />,
+    },
+    {
+      id: `{slugs.about-ai}|${lng}`,
+      path: i18n.t('slugs.about-ai', { lng }),
+      element: <AboutAi />,
     },
   ],
 }));


### PR DESCRIPTION
## Description

This pull request introduces improved UI feedback for the "Osaamiset" (Competence) status in the Koski education import feature. Key updates include:

- **New Attributes:** Added `osaamisetOdottaaTunnistusta` to track the competence identification status, `osaamisetTunnistusEpaonnistui` to display error when competence identification fails and `osasuoritukset`.
- **Loading Indicator:** Introduced a loading spinner for the AI-based competence recognition process.
- **Error Handling:** Implemented UI and logic for managing errors in AI-based competence detection.
- **Component Abstraction:** Refactored TooltipWrapper into a reusable standalone component.
- **New Page:** Created an 'About AI' page and linked it to the main navigation.
- **Code Cleanup:** Removed an obsolete TODO section from the ImportKoulutusSummaryModal component.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1306