### PR TITLE
OPHJOD-1492: Prevent actions dropdown from closing when clicking on a dialog

### DIFF
--- a/src/components/MoreActionsDropdown/MoreActionsDropdown.tsx
+++ b/src/components/MoreActionsDropdown/MoreActionsDropdown.tsx
@@ -25,13 +25,15 @@ const MoreActionsDropdown = ({ menuId, menuContent }: { menuId: string; menuCont
   }, [open]);
 
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    const relatedTarget = event.relatedTarget as HTMLElement;
+
     // Related target is the element that is focused after the menu loses focus.
-    // Do not close the menu if the related target is a DS confirm dialog.
-    if (event.relatedTarget?.id.includes('ds-confirm-dialog')) {
+    // Do not close the menu if the related target is part of the dialog portal root.
+    if (relatedTarget?.closest('#headlessui-portal-root')) {
       return;
     }
 
-    if (menuContentRef.current && !menuContentRef.current.contains(event.relatedTarget)) {
+    if (menuContentRef.current && !menuContentRef.current.contains(relatedTarget)) {
       setOpen(false);
     }
   };


### PR DESCRIPTION
## Description

* Ensure that the `MoreActionsDropdown` remains open when the user interacts with buttons in a dialog triggered by the actions menu, whether via mouse clicks or keyboard input.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1492
