### PR TITLE
OPHJOD-1560: Show education opportunity vaihe proposals only

### DIFF
--- a/src/api/mahdollisuusService.ts
+++ b/src/api/mahdollisuusService.ts
@@ -1,4 +1,5 @@
 import { client } from '@/api/client';
+import { TypedMahdollisuus } from '@/routes/types';
 
 export const getTyoMahdollisuusDetails = async (ids: string[]) => {
   if (ids.length === 0) {
@@ -19,6 +20,12 @@ export const getTyoMahdollisuusDetails = async (ids: string[]) => {
   return [];
 };
 
+export const getTypedTyoMahdollisuusDetails = async (ids: string[]): Promise<TypedMahdollisuus[]> =>
+  (await getTyoMahdollisuusDetails(ids)).map((mahdollisuus) => ({
+    ...mahdollisuus,
+    mahdollisuusTyyppi: 'TYOMAHDOLLISUUS',
+  }));
+
 export const getKoulutusMahdollisuusDetails = async (ids: string[]) => {
   if (ids.length === 0) {
     return [];
@@ -36,3 +43,9 @@ export const getKoulutusMahdollisuusDetails = async (ids: string[]) => {
   }
   return [];
 };
+
+export const getTypedKoulutusMahdollisuusDetails = async (ids: string[]): Promise<TypedMahdollisuus[]> =>
+  (await getKoulutusMahdollisuusDetails(ids)).map((mahdollisuus) => ({
+    ...mahdollisuus,
+    mahdollisuusTyyppi: 'KOULUTUSMAHDOLLISUUS',
+  }));

--- a/src/routes/Profile/Path/Path.tsx
+++ b/src/routes/Profile/Path/Path.tsx
@@ -345,19 +345,22 @@ const Path = () => {
   };
 
   const onCloseManualModal = async (isCancel: boolean) => {
+    setManualModalOpen(false);
+    setVaiheIndex(undefined);
+
     if (!isCancel) {
       await revalidator.revalidate();
     }
-    setManualModalOpen(false);
-    setVaiheIndex(undefined);
   };
   const onCloseProposeModal = async (isCancel: boolean) => {
     onCloseManualModal(isCancel);
+
+    setProposeModalOpen(false);
+    setVaiheIndex(undefined);
+
     if (!isCancel) {
       await revalidator.revalidate();
     }
-    setProposeModalOpen(false);
-    setVaiheIndex(undefined);
   };
 
   const onSubmit: FormSubmitHandler<PolkuForm> = async ({ data }: { data: PolkuForm }) => {

--- a/src/routes/Profile/Path/modal/ProposeVaiheModal/ProposeVaiheModal.tsx
+++ b/src/routes/Profile/Path/modal/ProposeVaiheModal/ProposeVaiheModal.tsx
@@ -185,27 +185,25 @@ const ProposeVaiheModal = ({ isOpen, onClose, vaiheIndex }: ProposeVaiheModalPro
                 iconSide="right"
               />
             )}
-            {wizardStep === 1 ||
-              (isEditMode && wizardStep === 0 && (
-                <>
-                  {!isEditMode && <Button label={t('previous')} variant="white" onClick={previousStep} />}
-                  <Button
-                    label={t('next')}
-                    variant="white"
-                    disabled={detailsStepHasErrors}
-                    onClick={nextStep}
-                    icon={<MdArrowForward size={24} />}
-                    iconSide="right"
-                  />
-                </>
-              ))}
-            {wizardStep === 2 ||
-              (isEditMode && wizardStep === 1 && (
-                <>
-                  <Button label={t('previous')} variant="white" onClick={previousStep} />
-                  <Button label={t('save')} variant="white" form={formId} />
-                </>
-              ))}
+            {((!isEditMode && wizardStep === 1) || (isEditMode && wizardStep === 0)) && (
+              <>
+                {!isEditMode && <Button label={t('previous')} variant="white" onClick={previousStep} />}
+                <Button
+                  label={t('next')}
+                  variant="white"
+                  disabled={detailsStepHasErrors}
+                  onClick={nextStep}
+                  icon={<MdArrowForward size={24} />}
+                  iconSide="right"
+                />
+              </>
+            )}
+            {((!isEditMode && wizardStep === 2) || (isEditMode && wizardStep === 1)) && (
+              <>
+                <Button label={t('previous')} variant="white" onClick={previousStep} />
+                <Button label={t('save')} variant="white" form={formId} />
+              </>
+            )}
           </div>
         }
       />

--- a/src/routes/Profile/Path/modal/ProposeVaiheModal/SelectOpportunityStep.tsx
+++ b/src/routes/Profile/Path/modal/ProposeVaiheModal/SelectOpportunityStep.tsx
@@ -1,8 +1,4 @@
-import { MahdollisuusTyyppiFilter } from '@/components/MahdollisuusTyyppiFilter/MahdollisuusTyyppiFilter';
-import { FilterButton } from '@/components/MobileFilterButton/MobileFilterButton';
-import { useMenuClickHandler } from '@/hooks/useMenuClickHandler';
 import { mapOsaaminenToUri } from '@/routes/Profile/Path/utils';
-import { MahdollisuusTyyppi } from '@/routes/types';
 import { useEhdotetutVaiheetStore } from '@/stores/useEhdotetutVaiheetStore';
 import { usePolutStore } from '@/stores/usePolutStore';
 import { PageChangeDetails, Pagination, RadioButtonGroup, Spinner, useMediaQueries } from '@jod/design-system';
@@ -11,39 +7,10 @@ import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/shallow';
 import VaiheOpportunityCard from './VaiheOpportunityCard';
 
-const Filters = ({
-  handleFilterChange,
-  filters,
-}: {
-  handleFilterChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  filters: string[];
-}) => {
-  const { t } = useTranslation();
-  const isFilterChecked = (value: MahdollisuusTyyppi) => filters.includes(value);
-  const jobFilterText = t('job-opportunities');
-  const educationFilterText = t('education-opportunities');
-
-  return (
-    <div className="flex flex-col gap-6">
-      <h2 className="text-heading-2">{t('do-filter')}</h2>
-      <div className="flex flex-col gap-5">
-        <MahdollisuusTyyppiFilter
-          jobFilterText={jobFilterText}
-          educationFilterText={educationFilterText}
-          isFilterChecked={isFilterChecked}
-          handleFilterChange={handleFilterChange}
-        />
-      </div>
-    </div>
-  );
-};
-
 const SelectOpportunityStep = ({ vaiheIndex }: { vaiheIndex: number }) => {
   const { t } = useTranslation();
-  const { sm, lg } = useMediaQueries();
-  const [filtersOpen, setFiltersOpen] = React.useState(false);
-  const filterMenuButtonRef = React.useRef<HTMLButtonElement>(null);
-  const filterMenuRef = useMenuClickHandler(() => setFiltersOpen(false), filterMenuButtonRef);
+  const { sm } = useMediaQueries();
+
   const {
     disabledOsaamiset,
     ignoredOsaamiset,
@@ -66,20 +33,17 @@ const SelectOpportunityStep = ({ vaiheIndex }: { vaiheIndex: number }) => {
     })),
   );
 
-  const { fetchEhdotukset, fetchPage, filters, isLoading, pageData, pageNr, pageSize, setFilters, totalItems } =
-    useEhdotetutVaiheetStore(
-      useShallow((state) => ({
-        fetchEhdotukset: state.fetchEhdotukset,
-        fetchPage: state.fetchPage,
-        filters: state.filters,
-        isLoading: state.isLoading,
-        pageData: state.pageData,
-        pageNr: state.pageNr,
-        pageSize: state.pageSize,
-        setFilters: state.setFilters,
-        totalItems: state.totalItems,
-      })),
-    );
+  const { fetchEhdotukset, fetchPage, isLoading, pageData, pageNr, pageSize, totalItems } = useEhdotetutVaiheetStore(
+    useShallow((state) => ({
+      fetchEhdotukset: state.fetchEhdotukset,
+      fetchPage: state.fetchPage,
+      isLoading: state.isLoading,
+      pageData: state.pageData,
+      pageNr: state.pageNr,
+      pageSize: state.pageSize,
+      totalItems: state.totalItems,
+    })),
+  );
 
   React.useEffect(() => {
     const fetchData = async () => {
@@ -98,42 +62,6 @@ const SelectOpportunityStep = ({ vaiheIndex }: { vaiheIndex: number }) => {
   }, []);
 
   const scrollRef = React.useRef<HTMLDivElement>(null);
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value as MahdollisuusTyyppi;
-    if (filters.includes(value)) {
-      if (filters.length > 1) {
-        setFilters(filters.filter((filter) => filter !== value));
-      }
-    } else {
-      setFilters([...filters, value]);
-    }
-    void fetchPage({ page: 1 });
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
-
-  type SelectedFilter = 'KAIKKI' | 'TYOMAHDOLLISUUS' | 'KOULUTUSMAHDOLLISUUS';
-
-  const selectedFilter: SelectedFilter = React.useMemo(() => {
-    if (filters.includes('TYOMAHDOLLISUUS') && filters.includes('KOULUTUSMAHDOLLISUUS')) {
-      return 'KAIKKI';
-    } else if (filters.includes('TYOMAHDOLLISUUS')) {
-      return 'TYOMAHDOLLISUUS';
-    } else if (filters.includes('KOULUTUSMAHDOLLISUUS')) {
-      return 'KOULUTUSMAHDOLLISUUS';
-    }
-    return 'KAIKKI';
-  }, [filters]);
-
-  const mahdollisuudetPerType = React.useMemo(() => {
-    switch (selectedFilter) {
-      case 'KAIKKI':
-        return pageData;
-      case 'TYOMAHDOLLISUUS':
-        return pageData.filter((mahdollisuus) => mahdollisuus.mahdollisuusTyyppi === 'TYOMAHDOLLISUUS');
-      case 'KOULUTUSMAHDOLLISUUS':
-        return pageData.filter((mahdollisuus) => mahdollisuus.mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS');
-    }
-  }, [pageData, selectedFilter]);
 
   const onPageChange = async (data: PageChangeDetails) => {
     await fetchPage(data);
@@ -155,69 +83,42 @@ const SelectOpportunityStep = ({ vaiheIndex }: { vaiheIndex: number }) => {
       {!isLoading && totalItems === 0 ? (
         <p className="mt-7">{t('profile.paths.proposed-opportunities-not-found')}</p>
       ) : (
-        <>
-          <div className="flex justify-end p-3">
-            <FilterButton
-              onClick={() => setFiltersOpen(!filtersOpen)}
-              label={t('do-filter')}
-              breakpoint="lg"
-              ref={filterMenuButtonRef}
-              inline
-            />
-          </div>
-
-          {filtersOpen && (
-            <div className="relative">
-              <div
-                className="flex flex-col absolute right-0 top-full z-10 bg-bg-gray-2 p-6 rounded-md mt-4 w-[343px] shadow-border text-left gap-6"
-                ref={filterMenuRef}
-              >
-                <Filters handleFilterChange={handleFilterChange} filters={filters} />
+        <div className="flex flex-row mt-6 gap-5" ref={scrollRef}>
+          <div className="flex flex-col gap-6">
+            <RadioButtonGroup
+              label={t('profile.paths.choose-one-opportunity')}
+              hideLabel
+              value={proposedOpportunity?.id ?? ''}
+              onChange={(id) => {
+                const opportunity = pageData.find((o) => o.id === id);
+                if (opportunity) {
+                  setProposedOpportunity(opportunity);
+                }
+              }}
+            >
+              <div className="flex flex-col gap-5">
+                {pageData.map((mahdollisuus) => (
+                  <VaiheOpportunityCard key={mahdollisuus.id} mahdollisuus={mahdollisuus} />
+                ))}
               </div>
-            </div>
-          )}
-          <div className="flex flex-row mt-6 gap-5" ref={scrollRef}>
-            <div className="flex flex-col gap-6">
-              <RadioButtonGroup
-                label={t('profile.paths.choose-one-opportunity')}
-                hideLabel
-                value={proposedOpportunity?.id ?? ''}
-                onChange={(id) => {
-                  const opportunity = pageData.find((o) => o.id === id);
-                  if (opportunity) {
-                    setProposedOpportunity(opportunity);
-                  }
-                }}
-              >
-                <div className="flex flex-col gap-5">
-                  {pageData.map((mahdollisuus) => (
-                    <VaiheOpportunityCard key={mahdollisuus.id} mahdollisuus={mahdollisuus} />
-                  ))}
-                </div>
-              </RadioButtonGroup>
-              {mahdollisuudetPerType.length > 0 && (
-                <div className="mt-5">
-                  <Pagination
-                    currentPage={pageNr}
-                    onPageChange={onPageChange}
-                    pageSize={pageSize}
-                    siblingCount={sm ? 1 : 0}
-                    translations={{
-                      nextTriggerLabel: t('pagination.next'),
-                      prevTriggerLabel: t('pagination.previous'),
-                    }}
-                    totalItems={totalItems}
-                  />
-                </div>
-              )}
-            </div>
-            {lg && (
-              <div className="p-5 bg-bg-gray-2 sticky top-0 rounded-md h-min">
-                <Filters handleFilterChange={handleFilterChange} filters={filters} />
+            </RadioButtonGroup>
+            {pageData.length > 0 && (
+              <div className="mt-5">
+                <Pagination
+                  currentPage={pageNr}
+                  onPageChange={onPageChange}
+                  pageSize={pageSize}
+                  siblingCount={sm ? 1 : 0}
+                  translations={{
+                    nextTriggerLabel: t('pagination.next'),
+                    prevTriggerLabel: t('pagination.previous'),
+                  }}
+                  totalItems={totalItems}
+                />
               </div>
             )}
           </div>
-        </>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* When getting vaihe proposals, only education opportunities are shown
* Filters removed from vaihe proposal modal
* Added the ability to get `TypedMahdollisuus` from `mahdollisuusService` for convenience
* Also fixed 2 unrelated bugs:
  * Some footer buttons were missing in vaihe proposal modal
  * When modal is closed after vaihe has been saved, an error page was visible for a short period

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1560
