### PR TITLE
OPHJOD-1588: Fetch all favorites in favorites page

### DIFF
--- a/src/routes/Profile/Favorites/loader.ts
+++ b/src/routes/Profile/Favorites/loader.ts
@@ -1,14 +1,12 @@
-import { client } from '@/api/client';
 import { components } from '@/api/schema';
 import { DEFAULT_PAGE_SIZE } from '@/constants';
 import { useSuosikitStore } from '@/stores/useSuosikitStore';
 import { LoaderFunction } from 'react-router';
 
-export default (async ({ request }) => {
+export default (async () => {
   const { setExcludedIds, fetchSuosikit, fetchPage } = useSuosikitStore.getState();
-  const response = await client.GET('/api/profiili/paamaarat', { signal: request.signal });
-  const paamaarat = response.data ?? [];
-  setExcludedIds(paamaarat.map((pm) => pm.mahdollisuusId));
+  // When navigating to favorites, reset excludedIds so that all favorites are shown
+  setExcludedIds([]);
   await fetchSuosikit();
   await fetchPage({ page: 1, pageSize: DEFAULT_PAGE_SIZE });
   return null;


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fetch all favorites when navigating to suosikkini page. It seems safe to just remove all excluded suosikki id's when navigating to suosikkini page. In päämääräni page, favorites that are already as goals are excluded, so there is no need to set any exclusions in suosikkini page.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1588
