### PR TITLE
OPHJOD-1705: Fix the bug of Tool's opportunity filter

### DIFF
--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -424,7 +424,7 @@ const ExploreOpportunities = () => {
             <span className="text-heading-4-mobile sm:text-heading-4">{t('show')}</span>
             <Checkbox
               ariaLabel={getCheckboxLabel('TYOMAHDOLLISUUS')}
-              checked={filter.includes('TYOMAHDOLLISUUS')}
+              checked={filter.includes('ALL') || filter.includes('TYOMAHDOLLISUUS')}
               label={getCheckboxLabel('TYOMAHDOLLISUUS')}
               name={filterValues.TYOMAHDOLLISUUS}
               onChange={onFilterChange}
@@ -433,7 +433,7 @@ const ExploreOpportunities = () => {
             />
             <Checkbox
               ariaLabel={getCheckboxLabel('KOULUTUSMAHDOLLISUUS')}
-              checked={filter.includes('KOULUTUSMAHDOLLISUUS')}
+              checked={filter.includes('ALL') || filter.includes('KOULUTUSMAHDOLLISUUS')}
               label={getCheckboxLabel('KOULUTUSMAHDOLLISUUS')}
               name={filterValues.KOULUTUSMAHDOLLISUUS}
               onChange={onFilterChange}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fix the bug of Tools' opportunity filter not showing anything when both "TYOMAHDOLLISUUS" and "KOULUTUSMAHDOLLISUUS" was checked as filter in Profile's Favorites and then clicking the link to go to Tools.

## Screenshots
_Screenshot to tell what filter in the Profile's Favorites is meant and what part of the Tool was affected._

### Step 1
<img width="600" alt="Step 1" src="https://github.com/user-attachments/assets/13be637a-6b7a-45b1-9f23-0a013bde3e63" />

### Step 2
<img width="600" alt="Step 2" src="https://github.com/user-attachments/assets/e4b72e40-8e63-41b4-b164-a7eac32ea658" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1705
