### PR TITLE
OPHJOD-1776: Update NavigationBar styles

### DIFF
--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -1,7 +1,8 @@
 import { LanguageMenu } from '@/components/LanguageMenu/LanguageMenu';
-import { langLabels } from '@/i18n/config';
+import { type LangCode, langLabels } from '@/i18n/config';
+import { useMediaQueries } from '@jod/design-system';
+import { JodCaretDown, JodCaretUp, JodLanguage } from '@jod/design-system/icons';
 import { useTranslation } from 'react-i18next';
-import { MdExpandLess, MdExpandMore, MdLanguage } from 'react-icons/md';
 
 interface LanguageButtonProps {
   onClick: () => void;
@@ -16,16 +17,21 @@ export const LanguageButton = ({ onClick, langMenuOpen, menuRef, onMenuBlur, onM
     i18n: { language: languageKey },
   } = useTranslation();
 
+  const { sm } = useMediaQueries();
+
+  const carets = sm ? <>{langMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
+
   return (
     <div className="relative">
-      <button onClick={onClick} className="flex gap-2 justify-center items-center select-none cursor-pointer">
-        <span className="size-7 flex justify-center items-center">
-          <MdLanguage size={24} />
+      <button
+        onClick={onClick}
+        className="flex flex-col sm:flex-row justify-center items-center select-none cursor-pointer sm:mr-5"
+      >
+        <JodLanguage className="mx-auto" />
+        <span className="whitespace-nowrap text-[12px] sm:text-button-sm sm:mx-3">
+          {langLabels[languageKey as LangCode]}
         </span>
-        <span className="py-3 whitespace-nowrap">{langLabels[languageKey as keyof typeof langLabels]}</span>
-        <span className="size-7 flex justify-center items-center">
-          {langMenuOpen ? <MdExpandLess size={24} /> : <MdExpandMore size={24} />}
-        </span>
+        {carets}
       </button>
       {langMenuOpen && (
         <div ref={menuRef} onBlur={onMenuBlur} className="absolute right-0 translate-y-8">

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -1,9 +1,9 @@
 import { components } from '@/api/schema';
 import { useMenuClickHandler } from '@/hooks/useMenuClickHandler';
-import { PopupList, PopupListItem } from '@jod/design-system';
+import { PopupList, PopupListItem, useMediaQueries } from '@jod/design-system';
+import { JodCaretDown, JodCaretUp, JodUser } from '@jod/design-system/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { MdExpandLess, MdExpandMore, MdPersonOutline } from 'react-icons/md';
 import { Link, NavLink, useLoaderData } from 'react-router';
 
 interface UserButtonProps {
@@ -17,6 +17,8 @@ export const UserButton = ({ onLogout, onClick }: UserButtonProps) => {
     i18n: { language },
   } = useTranslation();
 
+  const { sm } = useMediaQueries();
+
   const data = useLoaderData() as components['schemas']['YksiloCsrfDto'] | null;
 
   const [userMenuOpen, setUserMenuOpen] = React.useState(false);
@@ -29,22 +31,18 @@ export const UserButton = ({ onLogout, onClick }: UserButtonProps) => {
   const getActiveClassNames = ({ isActive }: { isActive: boolean }) => (isActive ? 'bg-secondary-1-50 rounded-sm' : '');
 
   const landingPageUrl = `/${language}/${t('slugs.profile.login')}`;
-  const fullName = `${data?.etunimi} ${data?.sukunimi}`;
+  const carets = sm ? <>{userMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
 
   return data?.csrf ? (
     <div className="relative">
       <button
         ref={userMenuButtonRef}
         onClick={() => setUserMenuOpen(!userMenuOpen)}
-        className="flex gap-2 justify-center items-center select-none cursor-pointer"
+        className="flex flex-col sm:flex-row justify-center items-center select-none cursor-pointer sm:mr-5"
       >
-        <span className="size-7 flex justify-center items-center">
-          <MdPersonOutline size={24} />
-        </span>
-        <span className="py-3 whitespace-nowrap">{fullName}</span>
-        <span className="size-7 flex justify-center items-center">
-          {userMenuOpen ? <MdExpandLess size={24} /> : <MdExpandMore size={24} />}
-        </span>
+        <JodUser className="mx-auto" />
+        <span className="whitespace-nowrap sm:text-button-sm text-[12px] sm:mx-3">{data?.etunimi}</span>
+        {carets}
       </button>
       {userMenuOpen && (
         <div ref={userMenuRef} className="absolute right-0 min-w-max translate-y-8 transform">
@@ -66,17 +64,15 @@ export const UserButton = ({ onLogout, onClick }: UserButtonProps) => {
   ) : (
     <Link
       to={landingPageUrl}
-      className="flex gap-2 justify-center items-center select-none cursor-pointer"
+      className="flex flex-col sm:flex-row sm:gap-2 justify-center items-center select-none cursor-pointer"
       onClick={() => {
         if (onClick) {
           onClick();
         }
       }}
     >
-      <span className="size-7 flex justify-center items-center">
-        <MdPersonOutline size={24} />
-      </span>
-      <span className="py-3 pr-2 whitespace-nowrap">{t('login')}</span>
+      <JodUser className="mx-auto" />
+      <span className="whitespace-nowrap text-[12px] sm:text-button-sm sm:mr-5">{t('login')}</span>
     </Link>
   );
 };

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -8,9 +8,9 @@ import { useMenuClickHandler } from '@/hooks/useMenuClickHandler';
 import { useErrorNoteStore } from '@/stores/useErrorNoteStore';
 import { useToolStore } from '@/stores/useToolStore';
 import { Footer, MatomoTracker, NavigationBar, SkipLink } from '@jod/design-system';
+import { JodMenu } from '@jod/design-system/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { MdMenu } from 'react-icons/md';
 import { Link, NavLink, Outlet, ScrollRestoration, useLoaderData, useLocation } from 'react-router';
 import { LogoutFormContext } from '.';
 
@@ -109,12 +109,10 @@ const Root = () => {
             <button
               onClick={() => setNavMenuOpen(!navMenuOpen)}
               aria-label={t('open-menu')}
-              className="flex gap-2 justify-center items-center select-none cursor-pointer"
+              className="flex flex-col sm:flex-row sm:gap-3 justify-center items-center select-none cursor-pointer"
             >
-              <span className="size-7 flex justify-center items-center">
-                <MdMenu size={24} />
-              </span>
-              <span className="py-3 pr-2">{t('menu')}</span>
+              <JodMenu className="mx-auto" />
+              <span className="md:pr-3 sm:text-button-sm text-[12px]">{t('menu')}</span>
             </button>
           }
           languageButtonComponent={


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

NavigationBar design update
* Smaller text size
* More space between buttons
* Button labels go under the icons on mobile
* Show users first name only
* Replace `react-icons` with SG icons

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1776

<img width="405" height="49" alt="image" src="https://github.com/user-attachments/assets/f2ec7a26-6025-4b4a-a09f-a16fbcc1c347" />

<img width="440" height="51" alt="image" src="https://github.com/user-attachments/assets/8ebc7bfa-1c34-4634-8e89-6e3e7f2d540e" />


<img width="212" height="52" alt="image" src="https://github.com/user-attachments/assets/feb8d659-294d-4ab7-afcb-764aac99f71d" />

<img width="210" height="58" alt="image" src="https://github.com/user-attachments/assets/3dfb5881-4036-449a-bcee-af1bbcfb76c3" />


