### PR TITLE
OPHJOD-1783: Update toaster position

### DIFF
--- a/src/components/Toaster/Toaster.tsx
+++ b/src/components/Toaster/Toaster.tsx
@@ -4,14 +4,18 @@ import { Toast as ReactHotToast, useToaster } from 'react-hot-toast/headless';
 type SafeToast = Omit<ReactHotToast, 'message'> & { message: string };
 
 export const Toaster = () => {
-  const { toasts, handlers } = useToaster();
+  const { toasts, handlers } = useToaster({ duration: 4000 });
   const { startPause, endPause } = handlers;
   const safeToasts = toasts.filter((toast): toast is SafeToast => typeof toast.message === 'string');
+  // Header 48px + 16px padding = 64px
+  // Service bar 40px when open, 4px when closed (scrollY > 0)
+  // Margin to edges is 32px according to design
+  const topClass = window.scrollY > 0 ? 'top-[100px]' : 'top-[136px]';
 
   return (
     <div
       role="alert"
-      className="fixed top-[80px] right-4 z-60 flex flex-col gap-4"
+      className={`fixed ${topClass} right-7 z-60 flex flex-col gap-4`}
       onMouseEnter={startPause}
       onMouseLeave={endPause}
     >


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Toasts now always appear 32px from the right side of the screen and 32px from the bottom of the header bar
* Added 4000ms default duration

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1783

<img width="291" height="167" alt="image" src="https://github.com/user-attachments/assets/b36b5abf-47a4-4db4-ad93-2fd850dab7d5" />
