### PR TITLE
OPHJOD-1846: Fix "start koski import modal" reopening after import has been finished

### DIFF
--- a/src/routes/Profile/EducationHistory/modals/AddOrEditKoulutusModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/AddOrEditKoulutusModal.tsx
@@ -328,7 +328,7 @@ const AddOrEditKoulutusModal = ({
                 onClick={() =>
                   showDialog({
                     title: t('education-history.delete-degree'),
-                    onConfirm: () => void deleteKoulutus(),
+                    onConfirm: deleteKoulutus,
                     description: t('education-history.confirm-delete-degree', {
                       name: getLocalizedText(methods.getValues('nimi')),
                     }),

--- a/src/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal.tsx
@@ -138,7 +138,7 @@ const EditKoulutuskokonaisuusModal = ({
               onClick={() => {
                 showDialog({
                   title: t('education-history.delete-education-history'),
-                  onConfirm: () => void deleteKoulutuskokonaisuus(),
+                  onConfirm: deleteKoulutuskokonaisuus,
                   description: t('education-history.confirm-delete-education-history', {
                     name: getLocalizedText(methods.getValues('nimi')),
                   }),

--- a/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
@@ -19,6 +19,7 @@ const ImportKoulutusSummaryModal = ({ isOpen, onSuccessful, onFailure }: ImportK
   const { t } = useTranslation();
   const { showDialog, closeActiveModal } = useModal();
   const [isFetching, setIsFetching] = React.useState<boolean>(false);
+  const [isSaving, setIsSaving] = React.useState<boolean>(false);
   const [koskiData, setKoskiData] = React.useState<components['schemas']['KoulutusDto'][] | undefined>(undefined);
   const [error, setError] = React.useState<Error | undefined>(undefined);
   const [tableRows, setTableRows] = React.useState<ExperienceTableRowData[]>([]);
@@ -144,6 +145,10 @@ const ImportKoulutusSummaryModal = ({ isOpen, onSuccessful, onFailure }: ImportK
   };
 
   const saveSelectedKoulutus = async () => {
+    if (isSaving) {
+      return;
+    }
+    setIsSaving(true);
     try {
       const koulutusKokonaisuudet = createKoulutusKokonaisuudet();
       const body: {
@@ -159,10 +164,13 @@ const ImportKoulutusSummaryModal = ({ isOpen, onSuccessful, onFailure }: ImportK
       await client.POST('/api/profiili/koulutuskokonaisuudet/tuonti', {
         body,
       });
+      closeActiveModal();
       onSuccessful();
     } catch (_) {
+      closeActiveModal();
       onFailure();
     }
+    setIsSaving(false);
   };
 
   if (!isOpen) {


### PR DESCRIPTION
## Description
* Fix the issue where the "Start koski import" modal would reappear after import has been finished already.
  * The issue was that the `ImportKoulutusSummaryModal` doesn't have an `onClose` prop or any closing logic, so the `handleClose` in `ModalProvider` (which closes active modal)  is never called. Fixed by calling `closeActiveModal` manually after the import call.
* Small unrelated fixes
  * When deleting koulutus or koulutuskokonaisuus, close modals only after API call has completed to prevent the edit modals flashing for a brief time
  * Only save selected imported koulutukset if save is not already pending to prevent multiple requests when spamming the save button.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1846
