### PR TITLE
OPHJOD-1881: Update ExperienceTable to be more screenreader friendly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1240,7 +1240,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#1e3c5d6f10a1239296f17ccc768e95d848727ca0",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#759401289bb7986faff2f7947af65bc0cf4408d8",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.18.3",

--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -184,6 +184,7 @@ export const ExperienceTableRow = ({
     if (onRowClick && row.osaamiset.length > 0) {
       return (
         <button
+          aria-expanded={isOpen}
           aria-label={t(isOpen ? 'close' : 'open')}
           onClick={() => setIsOpen(!isOpen)}
           className={`cursor-pointer flex gap-x-2 items-center ${sm ? 'text-nowrap pr-2' : 'pr-7'}`}
@@ -248,7 +249,7 @@ export const ExperienceTableRow = ({
       <tr>
         {isOpen && !showCheckbox && (
           <td colSpan={5} className={`w-full ${last ? 'px-5 pt-5' : 'p-5'}`.trim()}>
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap gap-3" aria-label={t('competences')}>
               {sortedCompetences.map((competence) => (
                 <Tag
                   label={getLocalizedText(competence.nimi)}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Update ExperienceTable
  - tells the state, `aria-expanded`, of the menu for the competences
  - the opened competences "area" has now label attached, so that user knows which are they
- Update `@jod/design/system` as it caused error because it was not updated.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1881
