### PR TITLE
OPHJOD-1911: Remove line that nulls kartoitetut osaaamiset from state

### DIFF
--- a/src/routes/JobOpportunity/loader.ts
+++ b/src/routes/JobOpportunity/loader.ts
@@ -57,19 +57,6 @@ const loader = (async ({ request, params, context }) => {
 
   if (context) {
     await useToolStore.getState().updateSuosikit(true);
-    const { data = [] } = await client.GET('/api/profiili/osaamiset');
-
-    const omatRelevantOsaamiset = data.filter((osaaminen) =>
-      competences.some((c) => c.uri === osaaminen.osaaminen.uri),
-    );
-
-    useToolStore.getState().setOsaamiset(
-      omatRelevantOsaamiset.map((x) => ({
-        id: x.osaaminen.uri,
-        kuvaus: x.osaaminen.kuvaus,
-        nimi: x.osaaminen.nimi,
-      })),
-    );
   }
   return {
     tyomahdollisuus,


### PR DESCRIPTION
Kartoitetut kiinnostukset nollautuvat aikaisemmin aina kun painoi työmahdollisuutta. Tämä nyt korjattu