### PR TITLE
OPHJOD-2077: Update to use IconHeading

### DIFF
--- a/src/components/IconHeading/index.tsx
+++ b/src/components/IconHeading/index.tsx
@@ -2,17 +2,29 @@ export interface IconHeadingProps {
   icon: React.ReactNode;
   title: string;
   dataTestId?: string;
+  bgClassName?: string;
+  textClassName?: string;
 }
 
-export const IconHeading = ({ icon, title, dataTestId }: IconHeadingProps) => {
+export const IconHeading = ({
+  icon,
+  title,
+  dataTestId,
+  bgClassName = 'bg-secondary-1-dark-2',
+  textClassName = 'text-secondary-1-dark-2',
+}: IconHeadingProps) => {
   return (
     <div className="mb-6 sm:mb-8 flex gap-x-4 items-center">
-      <span className="flex items-center justify-center size-9 aspect-square rounded-full bg-secondary-1-dark-2 text-white">
-        {icon}
-      </span>
+      {icon && (
+        <span
+          className={`flex items-center justify-center size-9 aspect-square rounded-full text-white ${bgClassName}`}
+        >
+          {icon}
+        </span>
+      )}
       <h1
         data-testid={dataTestId}
-        className="text-hero-mobile sm:text-hero text-secondary-1-dark-2 hyphens-auto text-pretty break-all"
+        className={`text-hero-mobile sm:text-hero hyphens-auto text-pretty break-all ${textClassName}`}
       >
         {title}
       </h1>

--- a/src/components/OpportunityDetails/OpportunityDetails.tsx
+++ b/src/components/OpportunityDetails/OpportunityDetails.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import { useShallow } from 'zustand/shallow';
 import { CounselingBanner } from '../CounselingBanner/CounselingBanner';
+import { IconHeading } from '../IconHeading';
 import RateAiContent from '../RateAiContent/RateAiContent';
 import { TooltipWrapper } from '../Tooltip/TooltipWrapper';
 
@@ -169,16 +170,12 @@ const OpportunityDetails = ({ data, isLoggedIn, tyyppi, sections, showAiInfoInTi
       {title ? <title>{title}</title> : null}
       <div className="flex flex-col">
         {!sm && OpportunityType}
-        {/* Header: Icon & title */}
-        <div className="flex gap-x-4 items-center">
-          <span className="flex items-center justify-center size-9 aspect-square rounded-full bg-secondary-1-dark-2">
-            <TitleIcon tyyppi={tyyppi} aineisto={jobData.aineisto} />
-          </span>
-          {title ? (
-            <h1 className="text-hero-mobile sm:text-hero text-secondary-1-dark-2 hyphens-auto text-pretty break-all">
-              {title}
-            </h1>
-          ) : null}
+        <div>
+          <IconHeading
+            icon={<TitleIcon tyyppi={tyyppi} aineisto={jobData.aineisto} />}
+            title={title}
+            dataTestId="opportunity-details-title"
+          />
           {showAiInfoInTitle && (
             <span className="print:hidden size-6">
               <AiInfo />

--- a/src/routes/Profile/components/ProfileSectionTitle.tsx
+++ b/src/routes/Profile/components/ProfileSectionTitle.tsx
@@ -1,5 +1,6 @@
+import { IconHeading } from '@/components/IconHeading';
 import { getTextClassByCompetenceSourceType, type ProfileSectionType } from '@/routes/Profile/utils';
-import { cx, tidyClasses } from '@jod/design-system';
+import { cx } from '@jod/design-system';
 import {
   JodCheckmarkAlt,
   JodFavorite,
@@ -36,21 +37,12 @@ export const ProfileSectionTitle = ({ type, title }: { type: ProfileSectionType;
   const showIcon = type && iconMap[type] !== null;
 
   return (
-    <div className="mb-5 text-heading-2 sm:text-heading-1 flex items-center gap-4">
-      {showIcon && (
-        <span className={`${iconBg} text-white rounded-full sm:size-9 size-8 justify-center items-center flex`}>
-          {iconMap[type]}
-        </span>
-      )}
-      <h1
-        className={tidyClasses([
-          'text-heading-1-mobile',
-          'sm:text-heading-1',
-          getTextClassByCompetenceSourceType(type),
-        ])}
-      >
-        {title}
-      </h1>
-    </div>
+    <IconHeading
+      icon={showIcon ? iconMap[type] : undefined}
+      title={title}
+      bgClassName={iconBg}
+      textClassName={getTextClassByCompetenceSourceType(type)}
+      dataTestId="profile-section-title"
+    />
   );
 };


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update `OpportunityDetails` and `ProfileSectionTitle` to use `IconHeading`
- Add `bgClassName` and `textClassName` props for the `IconHeading`

## Screenshots

Some examples:

<img width="200"  alt="SCR-20250918-novz" src="https://github.com/user-attachments/assets/9e602f01-d80b-4bbe-9d0a-6884937c7454" />
<img width="200"  alt="SCR-20250918-novg" src="https://github.com/user-attachments/assets/8d11f68b-2021-4fba-9e2e-5a8df95b7e87" />
<img width="200"  alt="SCR-20250918-noty" src="https://github.com/user-attachments/assets/0b76ed18-d741-42e1-bf4d-45a8b238a898" />
<img width="200"  alt="SCR-20250918-nosi" src="https://github.com/user-attachments/assets/ad90c137-22e8-46ed-bc1f-ef630ac0cecc" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2077
