### PR TITLE
OPHJOD-2116: Show a card that links to tool from profile pages and vice versa

### DIFF
--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -1085,6 +1085,11 @@
     "title": "Tietosuojaseloste ja evästeet"
   },
   "profile": {
+    "banner": {
+      "description": "Tallenna ja muokkaa tunnistamiasi osaamisia profiilissasi.",
+      "link-text": "Siirry profiiliin",
+      "title": "Oma osaamisprofiili"
+    },
     "competences": {
       "add": "Lisää osaamisia",
       "description": "Löydät alta kaikki osaamisesi, jotka olet tunnistanut tai lisännyt profiiliisi. Osaamisesi ryhmittelyn ja esitystavan voit valita itse.",
@@ -1411,6 +1416,11 @@
     "update-success": "Päivitys onnistui"
   },
   "tool": {
+    "banner": {
+      "description": "Löydä ammatti-, työ- ja koulutusmahdollisuuksia helposti kokeilemalla.",
+      "link-text": "Etsi mahdollisuuksia",
+      "title": "Etsi mahdollisuuksia"
+    },
     "competency-profile": {
       "description": "Tuo osaamisia profiilista tai vie valintasi sinne, jotta tietosi pysyvät yhdessä paikassa.",
       "help": "Tuo osaamisia osaamisprofiilistasi. Voit hyödyntää aiemmin tallentamiasi osaamisia mahdollisuuksien kartoittamisessa. Voit tuoda kaikki osaamiset tai vain ne, jotka haluat.\n\nVoit myös päivittää osaamisprofiiliasi tähän näkymään syöttämiesi uusien osaamisten ja kiinnostusten perusteella.",

--- a/src/routes/Profile/Competences/Competences.tsx
+++ b/src/routes/Profile/Competences/Competences.tsx
@@ -1,5 +1,6 @@
 import { MainLayout } from '@/components';
 import { FilterButton } from '@/components/MobileFilterButton/MobileFilterButton';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useInitializeFilters } from '@/hooks/useInitializeFilters';
 import { Filters } from '@/routes/Profile/Competences/Filters';
 import { GroupByAlphabet } from '@/routes/Profile/Competences/GroupByAlphabet';
@@ -7,11 +8,11 @@ import { GroupBySource } from '@/routes/Profile/Competences/GroupBySource';
 import type { CompetencesLoaderData } from '@/routes/Profile/Competences/loader';
 import { sortByProperty } from '@/utils';
 import { Button, Modal, useMediaQueries } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 import { type CompetenceSourceType, GROUP_BY_ALPHABET, GROUP_BY_SOURCE, GROUP_BY_THEME } from './constants';
 
 const Competences = () => {
@@ -26,6 +27,7 @@ const Competences = () => {
   const locale = language as 'fi' | 'sv';
   const [showFilters, setShowFilters] = React.useState(false);
   const { lg } = useMediaQueries();
+  const { isDev } = useEnvironment();
 
   const { selectedFilters, setSelectedFilters, filterKeys } = useInitializeFilters(
     locale,
@@ -43,7 +45,7 @@ const Competences = () => {
   const isOsaaminenVisible = React.useCallback(
     (type: CompetenceSourceType, id?: string): boolean => {
       return type === 'MUU_OSAAMINEN'
-        ? selectedFilters.MUU_OSAAMINEN.length > 0 && selectedFilters.MUU_OSAAMINEN.some((item) => item.checked)
+        ? selectedFilters.MUU_OSAAMINEN.some((item) => item.checked)
         : (selectedFilters[type]?.find((item) => (id ? item.value.includes(id) : false))?.checked ?? false);
     },
     [selectedFilters],
@@ -66,24 +68,13 @@ const Competences = () => {
             setGroupBy={setGroupBy}
             setSelectedFilters={setSelectedFilters}
           />
+          <ToolCard testId="competences-go-to-tool" />
         </div>
       }
     >
       <title>{title}</title>
       <ProfileSectionTitle type="OSAAMISENI" title={title} />
       <p className="mb-5 text-body-lg">{t('profile.competences.description')}</p>
-      <div className="mb-8">
-        <Link
-          to={`/${language}/${t('slugs.tool.index')}`}
-          className="text-button-md hover:underline text-accent mt-4"
-          data-testid="competences-go-to-tool"
-        >
-          <div className="flex items-center gap-2">
-            {t('profile.favorites.link-go-to-job-and-education-opportunities')}
-            <JodArrowRight size={24} />
-          </div>
-        </Link>
-      </div>
 
       <div>
         {!lg && (
@@ -131,7 +122,7 @@ const Competences = () => {
             data-testid="competences-group-by-source"
           />
         )}
-        {groupBy === GROUP_BY_THEME && <></>}
+        {isDev && groupBy === GROUP_BY_THEME && <></>}
         {groupBy === GROUP_BY_ALPHABET && (
           <GroupByAlphabet
             filters={selectedFilters}
@@ -150,6 +141,7 @@ const Competences = () => {
           />
         )}
       </div>
+      {lg ? null : <ToolCard testId="competences-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/Competences/Filters.tsx
+++ b/src/routes/Profile/Competences/Filters.tsx
@@ -1,4 +1,5 @@
 import { SimpleNavigationList } from '@/components';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { GROUP_BY_ALPHABET, GROUP_BY_SOURCE, GROUP_BY_THEME } from '@/routes/Profile/Competences/constants';
 import { RadioButton, RadioButtonGroup, useMediaQueries } from '@jod/design-system';
 import { useTranslation } from 'react-i18next';
@@ -12,6 +13,7 @@ interface FiltersProps extends CompetenceFiltersProps {
 export const Filters = ({ filterKeys, selectedFilters, setSelectedFilters, groupBy, setGroupBy }: FiltersProps) => {
   const { t } = useTranslation();
   const { sm } = useMediaQueries();
+  const { isDev } = useEnvironment();
 
   return (
     <>
@@ -28,7 +30,7 @@ export const Filters = ({ filterKeys, selectedFilters, setSelectedFilters, group
           hideLabel
         >
           <RadioButton label={t('profile.competences.group-by-source')} value={GROUP_BY_SOURCE} />
-          <RadioButton label={`TODO: ${t('profile.competences.group-by-theme')}`} value={GROUP_BY_THEME} />
+          {isDev && <RadioButton label={`TODO: ${t('profile.competences.group-by-theme')}`} value={GROUP_BY_THEME} />}
           <RadioButton label={t('profile.competences.group-by-alphabet')} value={GROUP_BY_ALPHABET} />
         </RadioButtonGroup>
       </SimpleNavigationList>

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -6,13 +6,13 @@ import { useModal } from '@/hooks/useModal';
 import { EducationHistoryWizard } from '@/routes/Profile/EducationHistory/EducationHistoryWizard';
 import EditKoulutuskokonaisuusModal from '@/routes/Profile/EducationHistory/modals/EditKoulutuskokonaisuusModal';
 import ImportKoulutusSummaryModal from '@/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal';
-import { Button, EmptyState } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
+import { Button, EmptyState, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData, useRevalidator, useSearchParams } from 'react-router';
+import { useLoaderData, useRevalidator, useSearchParams } from 'react-router';
 import { ProfileSectionTitle } from '../components';
 import { ProfileNavigationList } from '../components/index.tsx';
+import { ToolCard } from '../components/ToolCard.tsx';
 import AddOrEditKoulutusModal from './modals/AddOrEditKoulutusModal';
 import ImportKoulutusResultModal from './modals/ImportKoulutusResultModal';
 import ImportKoulutusStartModal from './modals/ImportKoulutusStartModal';
@@ -30,10 +30,8 @@ const EducationHistory = () => {
       }
     >;
   };
-  const {
-    t,
-    i18n: { language },
-  } = useTranslation();
+  const { t } = useTranslation();
+  const { lg } = useMediaQueries();
   const title = t('profile.education-history.title');
 
   const [rows, setRows] = React.useState<ExperienceTableRowData[]>(
@@ -242,32 +240,25 @@ const EducationHistory = () => {
 
     // Set up polling with an appropriate retry strategy
     React.useEffect(() => {
-      const interval = error ? 15_000 : 5_000;
+      const interval = error ? 15_000 : 5000;
       const intervalId = setInterval(fetchOsaamisetTunnistus, interval);
       return () => clearInterval(intervalId);
     }, [fetchOsaamisetTunnistus, error]);
   };
   usePollOsaamisetTunnistus(isOsaamisetTunnistusOngoing, rows, setRows, revalidator);
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="education-history-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="KOULUTUS" title={title} />
       <p className="mb-5 text-body-lg">{t('profile.education-history.description')}</p>
-      <div className="mb-8">
-        <Link
-          to={`/${language}/${t('slugs.tool.index')}`}
-          className="text-button-md hover:underline text-accent mt-4"
-          data-testid="education-history-go-to-tool"
-        >
-          <div className="flex items-center gap-2">
-            {t('profile.favorites.link-go-to-job-and-education-opportunities')}
-            <JodArrowRight size={24} />
-          </div>
-        </Link>
-      </div>
 
       {rows.length === 0 && (
         <div className="mt-6 mb-7" data-testid="education-history-empty-state">
@@ -309,6 +300,7 @@ const EducationHistory = () => {
           </TooltipWrapper>
         </div>
       </div>
+      {lg ? null : <ToolCard testId="education-history-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/Favorites/Favorites.tsx
+++ b/src/routes/Profile/Favorites/Favorites.tsx
@@ -6,13 +6,12 @@ import { filterValues } from '@/routes/Tool/utils.ts';
 import { MahdollisuusTyyppi } from '@/routes/types';
 import { useSuosikitStore } from '@/stores/useSuosikitStore';
 import { getLocalizedText } from '@/utils';
-import { getLinkTo } from '@/utils/routeUtils';
 import { Button, EmptyState, Modal, Pagination, useMediaQueries } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/shallow';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 import { getTypeSlug } from '../utils';
 
 const descriptionKeys = {
@@ -173,6 +172,7 @@ const Favorites = () => {
               handleFilterChange={handleFilterChange}
             />
           </SimpleNavigationList>
+          <ToolCard testId="favorites-go-to-tool" linkParams={`origin=favorites&filter=${getFilterValueForTools}`} />
         </div>
       }
     >
@@ -197,20 +197,6 @@ const Favorites = () => {
           <EmptyState text={t(descriptionKeys[selectedFilter])} data-testid="favorites-empty-state" />
         </div>
       )}
-
-      <div className="my-4">
-        <Button
-          LinkComponent={getLinkTo(
-            `/${language}/${t('slugs.tool.index')}?origin=favorites&filter=${getFilterValueForTools}`,
-          )}
-          label={t('profile.favorites.move-to-job-and-education-opportunities')}
-          icon={<JodArrowRight />}
-          iconSide="right"
-          variant="accent"
-          size="sm"
-          data-testid="favorites-go-to-tool"
-        />
-      </div>
 
       <div>
         {!lg && (
@@ -294,6 +280,7 @@ const Favorites = () => {
           data-testid="favorites-pagination"
         />
       )}
+      {lg ? null : <ToolCard testId="favorites-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/FreeTimeActivities/FreeTimeActivities.tsx
+++ b/src/routes/Profile/FreeTimeActivities/FreeTimeActivities.tsx
@@ -1,12 +1,12 @@
 import { ExperienceTable, MainLayout, type ExperienceTableRowData } from '@/components';
 import { useModal } from '@/hooks/useModal';
 import { EditVapaaAjanToimintoModal } from '@/routes/Profile/FreeTimeActivities/modals/EditVapaaAjanToimintoModal';
-import { EmptyState } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
+import { EmptyState, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 import { FreeTimeActivitiesWizard } from './FreeTimeActivitiesWizard';
 import { AddOrEditPatevyysModal } from './modals/AddOrEditPatevyysModal';
 import { getFreeTimeActivitiesTableRows, type VapaaAjanToiminto } from './utils';
@@ -23,10 +23,8 @@ const FreeTimeActivities = () => {
       }
     >;
   };
-  const {
-    t,
-    i18n: { language },
-  } = useTranslation();
+  const { t } = useTranslation();
+  const { lg } = useMediaQueries();
   const title = t('profile.free-time-activities.title');
   const [rows, setRows] = React.useState(getFreeTimeActivitiesTableRows(vapaaAjanToiminnot, osaamisetMap));
   const { showModal } = useModal();
@@ -53,25 +51,19 @@ const FreeTimeActivities = () => {
     showModal(AddOrEditPatevyysModal, { toimintoId: row.key });
   };
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="free-time-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="PATEVYYS" title={title} />
       <p className="mb-5 text-body-lg">{t('profile.free-time-activities.description')}</p>
-      <div className="mb-8">
-        <Link
-          to={`/${language}/${t('slugs.tool.index')}`}
-          className="text-button-md hover:underline text-accent mt-4"
-          data-testid="free-time-go-to-tool"
-        >
-          <div className="flex items-center gap-2">
-            {t('profile.favorites.link-go-to-job-and-education-opportunities')}
-            <JodArrowRight size={24} />
-          </div>
-        </Link>
-      </div>
+
       {rows.length === 0 && (
         <div className="mt-6 mb-7" data-testid="free-time-empty-state">
           <EmptyState text={t('profile.free-time-activities.empty')} />
@@ -90,6 +82,7 @@ const FreeTimeActivities = () => {
         onNestedRowClick={onNestedRowClick}
         onAddNestedRowClick={onAddNestedRowClick}
       />
+      {lg ? null : <ToolCard testId="free-time-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/Interests/Interests.tsx
+++ b/src/routes/Profile/Interests/Interests.tsx
@@ -6,14 +6,14 @@ import { useModal } from '@/hooks/useModal';
 import EditKiinnostusModal from '@/routes/Profile/Interests/EditKiinnostusModal';
 import { getLocalizedText, sortByProperty } from '@/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button, EmptyState, Tag, Textarea } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
+import { Button, EmptyState, Tag, Textarea, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 import { z } from 'zod';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 
 const Interests = () => {
   const {
@@ -21,6 +21,7 @@ const Interests = () => {
     i18n: { language },
   } = useTranslation();
   const { showModal } = useModal();
+  const { lg } = useMediaQueries();
   const { kiinnostukset, vapaateksti } = useLoaderData() as {
     kiinnostukset: components['schemas']['OsaaminenDto'][];
     vapaateksti: components['schemas']['LokalisoituTeksti'];
@@ -82,25 +83,19 @@ const Interests = () => {
     }
   }, [fields]);
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="interests-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="KIINNOSTUS" title={title} />
       <p className="mb-5 text-body-lg">{t('profile.interests.description')}</p>
-      <div className="mb-8">
-        <Link
-          to={`/${language}/${t('slugs.tool.index')}`}
-          className="text-button-md hover:underline text-accent mt-4"
-          data-testid="interests-go-to-tool"
-        >
-          <div className="flex items-center gap-2">
-            {t('profile.favorites.link-go-to-job-and-education-opportunities')}
-            <JodArrowRight size={24} />
-          </div>
-        </Link>
-      </div>
+
       {sortedSkills.length === 0 && (
         <div className="mt-6 mb-7">
           <EmptyState text={t('profile.interests.empty')} data-testid="interests-empty-state" />
@@ -163,6 +158,7 @@ const Interests = () => {
         }}
         data-testid="interests-freeform"
       />
+      {lg ? null : <ToolCard testId="interests-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/MyGoals/MyGoals.tsx
+++ b/src/routes/Profile/MyGoals/MyGoals.tsx
@@ -2,12 +2,11 @@ import { MainLayout } from '@/components';
 import { useModal } from '@/hooks/useModal';
 import { usePaamaaratStore } from '@/stores/usePaamaaratStore';
 import { useSuosikitStore } from '@/stores/useSuosikitStore';
-import { Button, EmptyState } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
+import { Button, EmptyState, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 import AddGoalModal from './AddGoalModal';
 import MyGoalsSection from './MyGoalsSection';
 
@@ -38,10 +37,8 @@ const AwardIcon = ({ color }: { color: 'gold' | 'silver' }) => {
 };
 
 const MyGoals = () => {
-  const {
-    t,
-    i18n: { language },
-  } = useTranslation();
+  const { t } = useTranslation();
+  const { lg } = useMediaQueries();
   const title = t('profile.my-goals.title');
   const { showModal } = useModal();
   const suosikitIsEmpty = useSuosikitStore(
@@ -58,10 +55,15 @@ const MyGoals = () => {
     };
   }, [paamaarat]);
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="goals-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="PAAMAARA" title={title} />
       <div className="flex flex-col gap-4 mb-9 sm:text-body-lg text-body-lg-mobile">
@@ -92,19 +94,6 @@ const MyGoals = () => {
           <div className="mt-6 mb-7">
             <EmptyState text={t('profile.my-goals.no-favorites-selected')} data-testid="goals-empty-state" />
           </div>
-          <Link
-            to={`/${language}/${t('slugs.tool.index')}`}
-            type="button"
-            className="text-button-md hover:underline text-accent"
-            data-testid="goals-add-favorites-link"
-          >
-            <div className="flex flex-row justify-start">
-              <div className="flex items-center gap-2">
-                {t('profile.my-goals.add-favorites-link')}
-                <JodArrowRight />
-              </div>
-            </div>
-          </Link>
         </div>
       )}
       <Button
@@ -116,6 +105,7 @@ const MyGoals = () => {
         disabled={suosikitIsEmpty}
         data-testid="goals-add-favorites-button"
       />
+      {lg ? null : <ToolCard testId="goals-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/Preferences/Preferences.tsx
+++ b/src/routes/Profile/Preferences/Preferences.tsx
@@ -4,11 +4,12 @@ import { MainLayout } from '@/components';
 import { useModal } from '@/hooks/useModal';
 import { LogoutFormContext } from '@/routes/Root';
 import { useToolStore } from '@/stores/useToolStore';
-import { Button, Toggle } from '@jod/design-system';
+import { Button, Toggle, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRouteLoaderData } from 'react-router';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 
 const DownloadLink = ({ children }: { children: React.ReactNode }) => (
   <a href={`${import.meta.env.BASE_URL}api/profiili/yksilo/vienti`}>{children}</a>
@@ -48,6 +49,7 @@ const ToggleWithText = ({
 
 const Preferences = () => {
   const { t } = useTranslation();
+  const { lg } = useMediaQueries();
   const title = t('profile.preferences.title');
   const toolStore = useToolStore();
   const logoutForm = React.useContext(LogoutFormContext);
@@ -97,10 +99,15 @@ const Preferences = () => {
     data?.tervetuloapolku,
   ]);
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="preferences-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="ASETUKSENI" title={title} />
       <div className="mb-8 text-body-lg flex flex-col gap-7">
@@ -156,6 +163,7 @@ const Preferences = () => {
           data-testid="pref-delete-profile"
         />
       </section>
+      {lg ? null : <ToolCard testId="preferences-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/ProfileFront/ProfileFront.tsx
+++ b/src/routes/Profile/ProfileFront/ProfileFront.tsx
@@ -1,10 +1,11 @@
 import type { components } from '@/api/schema';
 import { MainLayout } from '@/components';
 import { useYksiloData } from '@/hooks/useYksiloData';
-import React from 'react';
+import { useMediaQueries } from '@jod/design-system';
 import { useTranslation } from 'react-i18next';
 import { Link, useRouteLoaderData } from 'react-router';
 import { ProfileNavigationList } from '../components';
+import { ToolCard } from '../components/ToolCard';
 import WelcomePathModal from '../WelcomePathModal/WelcomePathModal';
 
 const ListItem = ({ label }: { label: string }) => <li className="list-disc ml-7 pl-4">{label}</li>;
@@ -14,13 +15,19 @@ const ProfileFront = () => {
     t,
     i18n: { language },
   } = useTranslation();
+  const { lg } = useMediaQueries();
   const rootLoaderData = useRouteLoaderData('root') as components['schemas']['YksiloCsrfDto'];
   const { data, isLoading } = useYksiloData();
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="profile-front-go-to-tool" />
+        </div>
+      }
+    >
       <title>{t('profile.front.title')}</title>
       <h1 className="mb-5 text-heading-2 sm:text-heading-1" data-testid="profile-front-title">
         {t('welcome', { name: rootLoaderData.etunimi ?? 'Nimetön' })}
@@ -54,6 +61,7 @@ const ProfileFront = () => {
           </Link>
         </p>
       </div>
+      {lg ? null : <ToolCard testId="profile-front-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/SomethingElse/SomethingElse.tsx
+++ b/src/routes/Profile/SomethingElse/SomethingElse.tsx
@@ -7,14 +7,14 @@ import { useModal } from '@/hooks/useModal';
 import EditMuuOsaaminenModal from '@/routes/Profile/SomethingElse/EditMuuOsaaminenModal';
 import { getLocalizedText, sortByProperty } from '@/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button, EmptyState, Tag, Textarea } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
+import { Button, EmptyState, Tag, Textarea, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 import { z } from 'zod';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 
 const SomethingElse = () => {
   const {
@@ -23,6 +23,7 @@ const SomethingElse = () => {
   } = useTranslation();
   const title = t('profile.something-else.title');
   const { showModal } = useModal();
+  const { lg } = useMediaQueries();
   const { muuOsaaminen, vapaateksti } = useLoaderData() as {
     muuOsaaminen: OsaaminenDto[];
     vapaateksti: components['schemas']['LokalisoituTeksti'];
@@ -80,25 +81,19 @@ const SomethingElse = () => {
     }
   }, [fields]);
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="something-else-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="MUU_OSAAMINEN" title={title} />
       <p className="mb-5 text-body-lg">{t('profile.something-else.description')}</p>
-      <div className="mb-8">
-        <Link
-          to={`/${language}/${t('slugs.tool.index')}`}
-          className="text-button-md hover:underline text-accent mt-4"
-          data-testid="something-else-go-to-tool"
-        >
-          <div className="flex items-center gap-2">
-            {t('profile.favorites.link-go-to-job-and-education-opportunities')}
-            <JodArrowRight size={24} />
-          </div>
-        </Link>
-      </div>
+
       {muuOsaaminen.length === 0 && (
         <div className="mt-6 mb-7" data-testid="something-else-empty-state">
           <EmptyState text={t('profile.something-else.empty')} />
@@ -142,6 +137,7 @@ const SomethingElse = () => {
         }}
         data-testid="something-else-freeform"
       />
+      {lg ? null : <ToolCard testId="something-else-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/WorkHistory/WorkHistory.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistory.tsx
@@ -2,12 +2,12 @@ import { ExperienceTable, MainLayout, type ExperienceTableRowData } from '@/comp
 import { useModal } from '@/hooks/useModal';
 import EditTyonantajaModal from '@/routes/Profile/WorkHistory/modals/EditTyonantajaModal';
 import { WorkHistoryWizard } from '@/routes/Profile/WorkHistory/WorkHistoryWizard';
-import { EmptyState } from '@jod/design-system';
-import { JodArrowRight } from '@jod/design-system/icons';
+import { EmptyState, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
+import { ToolCard } from '../components/ToolCard';
 import AddOrEditToimenkuvaModal from './modals/AddOrEditToimenkuvaModal';
 import { Tyopaikka, getWorkHistoryTableRows } from './utils';
 
@@ -23,13 +23,11 @@ const WorkHistory = () => {
       }
     >;
   };
-  const {
-    t,
-    i18n: { language },
-  } = useTranslation();
+  const { t } = useTranslation();
   const title = t('profile.work-history.title');
   const [rows, setRows] = React.useState(getWorkHistoryTableRows(tyopaikat, osaamisetMap));
   const { showModal } = useModal();
+  const { lg } = useMediaQueries();
 
   React.useEffect(() => {
     setRows(getWorkHistoryTableRows(tyopaikat, osaamisetMap));
@@ -54,25 +52,19 @@ const WorkHistory = () => {
     showModal(AddOrEditToimenkuvaModal, { tyopaikkaId: row.key });
   };
 
-  const navChildren = React.useMemo(() => <ProfileNavigationList />, []);
-
   return (
-    <MainLayout navChildren={navChildren}>
+    <MainLayout
+      navChildren={
+        <div className="flex flex-col gap-5">
+          <ProfileNavigationList />
+          <ToolCard testId="work-history-go-to-tool" />
+        </div>
+      }
+    >
       <title>{title}</title>
       <ProfileSectionTitle type="TOIMENKUVA" title={title} />
       <p className="mb-5 text-body-lg">{t('profile.work-history.description')}</p>
-      <div className="mb-8">
-        <Link
-          to={`/${language}/${t('slugs.tool.index')}`}
-          className="text-button-md hover:underline text-accent mt-4"
-          data-testid="work-history-go-to-tool"
-        >
-          <div className="flex items-center gap-2">
-            {t('profile.favorites.link-go-to-job-and-education-opportunities')}
-            <JodArrowRight size={24} />
-          </div>
-        </Link>
-      </div>
+
       {rows.length === 0 && (
         <div className="mt-6 mb-7" data-testid="work-history-empty-state">
           <EmptyState text={t('profile.work-history.empty')} />
@@ -90,6 +82,7 @@ const WorkHistory = () => {
         onNestedRowClick={onNestedRowClick}
         onAddNestedRowClick={onAddNestedRowClick}
       />
+      {lg ? null : <ToolCard testId="work-history-go-to-tool" className="mt-6" />}
     </MainLayout>
   );
 };

--- a/src/routes/Profile/components/ToolCard.tsx
+++ b/src/routes/Profile/components/ToolCard.tsx
@@ -1,0 +1,42 @@
+import { getLinkTo } from '@/utils/routeUtils';
+import { Button, tidyClasses } from '@jod/design-system';
+import { JodArrowRight } from '@jod/design-system/icons';
+import { useTranslation } from 'react-i18next';
+
+interface ToolCardProps {
+  /** Class name for the banner wrapper element */
+  className?: string;
+  /** Variant for the button */
+  buttonVariant?: React.ComponentProps<typeof Button>['variant'];
+  /** Data-testId attribute for the button */
+  testId?: string;
+  /** Optional query parameters to append to the tool URL */
+  linkParams?: string;
+}
+/**
+ * Card component that links to the main tool page.
+ */
+export const ToolCard = ({ testId = 'go-to-tool', linkParams, className, buttonVariant = 'white' }: ToolCardProps) => {
+  const { t, i18n } = useTranslation();
+  const to = linkParams
+    ? `/${i18n.language}/${t('slugs.tool.index')}?${linkParams}`
+    : `/${i18n.language}/${t('slugs.tool.index')}`;
+
+  return (
+    <div className={tidyClasses(`flex flex-col rounded-lg p-6 gap-5 bg-secondary-1-dark-2 ${className}`)}>
+      <div className="text-heading-2 text-white mr-2">{t('tool.banner.title')}</div>
+      <p className="text-body-lg text-white">{t('tool.banner.description')}</p>
+      <div className="mt-4">
+        <Button
+          label={t('tool.banner.link-text')}
+          variant={buttonVariant}
+          size="lg"
+          LinkComponent={getLinkTo(to)}
+          iconSide="right"
+          dataTestId={testId}
+          icon={<JodArrowRight />}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -1,4 +1,6 @@
+import type { components } from '@/api/schema';
 import { Breadcrumb, OpportunityCard } from '@/components';
+import { NavLinkBasedOnAuth } from '@/components/NavMenu/NavLinkBasedOnAuth';
 import { RateAiContent } from '@/components/RateAiContent/RateAiContent';
 import { useInteractionMethod } from '@/hooks/useInteractionMethod';
 import { useMenuClickHandler } from '@/hooks/useMenuClickHandler';
@@ -8,10 +10,10 @@ import ToolOpportunityCardActionMenu from '@/routes/Tool/ToolOpportunityCardActi
 import { useToolStore } from '@/stores/useToolStore';
 import { getLocalizedText } from '@/utils';
 import { Button, cx, Spinner, useMediaQueries } from '@jod/design-system';
-import { JodClose, JodCompass, JodSettings } from '@jod/design-system/icons';
+import { JodArrowRight, JodClose, JodCompass, JodSettings } from '@jod/design-system/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLoaderData } from 'react-router';
+import { useLoaderData, useRouteLoaderData } from 'react-router';
 import { useShallow } from 'zustand/shallow';
 import Competences from './Competences';
 import ToolAccordion from './components/ToolAccordion';
@@ -158,6 +160,22 @@ const ExploreOpportunities = () => {
   );
 };
 
+const ProfileLinkComponent = ({ className, children }: { className?: string; children: React.ReactNode }) => {
+  const rootLoaderData = useRouteLoaderData('root') as components['schemas']['YksiloCsrfDto'];
+  const { t, i18n } = useTranslation();
+
+  return (
+    <NavLinkBasedOnAuth
+      className={className}
+      to={`${t('slugs.profile.index')}/${t('slugs.profile.front')}`}
+      shouldLogin={!rootLoaderData}
+      lang={i18n.language}
+    >
+      {children}
+    </NavLinkBasedOnAuth>
+  );
+};
+
 const YourInfo = () => {
   const { t } = useTranslation();
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -185,6 +203,22 @@ const YourInfo = () => {
       </ToolAccordion>
 
       <RateAiContent onDislike={noop} onLike={noop} variant="kohtaanto" />
+
+      <div className="flex flex-col rounded-lg p-6 gap-5 mt-4 bg-secondary-1-dark-2">
+        <div className="text-heading-2 text-white mr-2">{t('profile.banner.title')}</div>
+        <p className="text-body-lg text-white">{t('profile.banner.description')}</p>
+        <div className="mt-4">
+          <Button
+            label={t('profile.banner.link-text')}
+            variant="white"
+            size="lg"
+            LinkComponent={ProfileLinkComponent}
+            iconSide="right"
+            dataTestId="tool-go-to-profile"
+            icon={<JodArrowRight />}
+          />
+        </div>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Show a card that has a link to tool in all profile pages
  * When the sidebar is hidden, the link card is displayed at the bottom of the page content.
* Show a card that has a link to profile front page in tool.
* Show TODO-tagged "group by theme" functionality in profile competences page only in development environment.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2116

<img width="386" height="825" alt="image" src="https://github.com/user-attachments/assets/56761baa-77f7-42f8-b7ff-f938e2585b31" />

<img width="594" height="988" alt="image" src="https://github.com/user-attachments/assets/cd28c983-23cd-4706-a197-b847c7c7acb4" />


<img width="464" height="916" alt="image" src="https://github.com/user-attachments/assets/4ca6c649-1cff-447d-9647-df6a78cee1a9" />

