### PR TITLE
OPHJOD-2172: Add icon heading to profile front page

### DIFF
--- a/src/components/IconHeading/index.tsx
+++ b/src/components/IconHeading/index.tsx
@@ -24,7 +24,7 @@ export const IconHeading = ({
       )}
       <h1
         data-testid={dataTestId}
-        className={`text-hero-mobile sm:text-hero hyphens-auto text-pretty break-all ${textClassName}`}
+        className={`text-hero-mobile sm:text-hero hyphens-auto text-pretty break-words ${textClassName}`}
       >
         {title}
       </h1>

--- a/src/routes/Profile/ProfileFront/ProfileFront.tsx
+++ b/src/routes/Profile/ProfileFront/ProfileFront.tsx
@@ -1,7 +1,9 @@
 import type { components } from '@/api/schema';
 import { MainLayout } from '@/components';
+import { IconHeading } from '@/components/IconHeading';
 import { useYksiloData } from '@/hooks/useYksiloData';
 import { useMediaQueries } from '@jod/design-system';
+import { JodUser } from '@jod/design-system/icons';
 import { useTranslation } from 'react-i18next';
 import { Link, useRouteLoaderData } from 'react-router';
 import { ProfileNavigationList } from '../components';
@@ -29,9 +31,11 @@ const ProfileFront = () => {
       }
     >
       <title>{t('profile.front.title')}</title>
-      <h1 className="mb-5 text-heading-2 sm:text-heading-1" data-testid="profile-front-title">
-        {t('welcome', { name: rootLoaderData.etunimi ?? 'Nimetön' })}
-      </h1>
+      <IconHeading
+        icon={<JodUser />}
+        title={t('welcome', { name: rootLoaderData.etunimi ?? 'Nimetön' })}
+        dataTestId="profile-front-title"
+      />
 
       {!isLoading && !data.tervetuloapolku && <WelcomePathModal yksiloData={data} />}
 


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

* Use `IconHeading` in profile front page
* Change how `IconHeading` wraps/breaks the heading text

## Related JIRA ticket


https://jira.eduuni.fi/browse/OPHJOD-2172

<img width="790" height="385" alt="image" src="https://github.com/user-attachments/assets/adbef286-6ac6-48d4-a0d1-8ef26860c6af" />

