### PR TITLE
OPHJOD-2222: Update RateAiContent modal, fix a11y issues, only on dev

### DIFF
--- a/src/components/RateAiContent/RateAiContent.tsx
+++ b/src/components/RateAiContent/RateAiContent.tsx
@@ -1,7 +1,9 @@
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useModal } from '@/hooks/useModal';
 import { Textarea } from '@jod/design-system';
 import { JodAi, JodThumbDown, JodThumbDownFilled, JodThumbUp, JodThumbUpFilled } from '@jod/design-system/icons';
 import React from 'react';
+import toast from 'react-hot-toast/headless';
 import { useTranslation } from 'react-i18next';
 
 interface RateAiContentProps {
@@ -18,49 +20,68 @@ export const RateAiContent = ({ isLiked, isDisliked, onLike, onDislike, variant 
   const DislikeIcon = isDisliked ? JodThumbDownFilled : JodThumbDown;
   const { showDialog } = useModal();
   const dislikeRef = React.useRef('');
+  const { isDev } = useEnvironment();
 
   const headerText =
     variant === 'kohtaanto' ? t('rate-ai-content.kohtaanto.header') : t('rate-ai-content.mahdollisuus.header');
   const bodyDescription =
     variant === 'kohtaanto' ? t('rate-ai-content.kohtaanto.body') : t('rate-ai-content.mahdollisuus.body');
 
-  return (
+  return isDev ? (
     <div className="bg-accent flex flex-col rounded-lg min-h-[271px] p-6">
       <div className="flex items-start mb-2">
         <div className="text-heading-2 text-white mr-2">{headerText}</div>
         <div className="text-white">
-          <JodAi size={32} />
+          <JodAi aria-label={t('rate-ai-content.icon')} size={32} />
         </div>
       </div>
       <div className="flex items-center mb-2">
         <p className="text-body-lg text-white">{bodyDescription}</p>
       </div>
-      <div className="bg-white flex items-center justify-between px-5 w-[128px] h-9 rounded-[30px] mt-auto">
-        <span className="bg-white rounded-full flex items-center px-3">
-          <LikeIcon className="text-accent cursor-pointer" onClick={onLike} />
-        </span>
-        <div className="h-9 w-1 bg-border-gray" aria-hidden="true" />
-        <span className="bg-white rounded-full flex items-center justify-center px-3">
-          <DislikeIcon
+      <div className="flex flex-row items-center justify-between w-[128px] h-9 rounded-[30px] mt-auto">
+        <button
+          className="bg-white rounded-l-[30px] flex-1 h-full w-full items-center justify-center pl-6 pr-5 flex"
+          aria-label={t('rate-ai-content.like')}
+        >
+          <LikeIcon
             className="text-accent cursor-pointer"
-            onClick={() =>
-              showDialog({
-                title: t('rate-ai-content.modal-header'),
-                content: (
-                  <Textarea
-                    onChange={(e) => {
-                      dislikeRef.current = e.target.value;
-                    }}
-                    placeholder={t('rate-ai-content.modal-placeholder')}
-                  />
-                ),
-                description: t('rate-ai-content.modal-body'),
-                onConfirm: () => onDislike(dislikeRef.current),
-              })
-            }
+            onClick={() => {
+              onLike();
+              toast.success(t('rate-ai-content.toast'));
+            }}
           />
-        </span>
+        </button>
+        <div className="h-9 min-w-1 bg-border-gray" aria-hidden="true" />
+        <button
+          className="bg-white rounded-r-[30px] flex-1 h-full items-center justify-center pl-5 pr-6 flex"
+          aria-label={t('rate-ai-content.dislike')}
+          onClick={() =>
+            showDialog({
+              variant: 'normal',
+              title: t('rate-ai-content.modal.header'),
+              cancelText: t('rate-ai-content.modal.close'),
+              confirmText: t('rate-ai-content.modal.send'),
+              content: (
+                <Textarea
+                  onChange={(e) => {
+                    dislikeRef.current = e.target.value;
+                  }}
+                  placeholder={t('rate-ai-content.modal.placeholder')}
+                />
+              ),
+              description: t('rate-ai-content.modal.body'),
+              onConfirm: () => {
+                onDislike(dislikeRef.current);
+                toast.success(t('rate-ai-content.toast'));
+              },
+            })
+          }
+        >
+          <DislikeIcon className="text-accent cursor-pointer" />
+        </button>
       </div>
     </div>
+  ) : (
+    <></>
   );
 };

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -908,18 +908,25 @@
   "proposed-competences": "Ehdotetut osaamiset",
   "proposed-interests": "Ehdotetut kiinnostukset",
   "rate-ai-content": {
+    "dislike": "En tykkää",
+    "icon": "Tekoälyllä tuotettu sisältöä",
     "kohtaanto": {
-      "body": "Tällä sivulla ehdotetaan syöttämiesi tietojen perusteella sinulle sopivia mahdollisuuksia. Kerro miten onnistuimme?",
+      "body": "Tällä sivulla ehdotetaan syöttämiesi tietojen perusteella sinulle sopivia mahdollisuuksia. Kerro miten onnistuimme.",
       "header": "Arvioi sinulle ehdotettuja mahdollisuuksia"
     },
+    "like": "Tykkään",
     "mahdollisuus": {
-      "body": "Tällä sivulla on tekoälyn avulla luotua sisältöä - se saattaa sisältää virheitä. Kerro miten onnistuimme?",
+      "body": "Tällä sivulla on tekoälyn avulla luotua sisältöä - se saattaa sisältää virheitä. Kerro miten onnistuimme.",
       "header": "Arvioi tekoälyn tuottamaa sisältöä"
     },
-    "modal-body": "Huomasimme, että annoit peukun alas tekoälyn tuottamalle sisällölle. Voisitko kertoa tarkemmin, mikä ei toiminut? Palautteesi auttaa meitä kehittämään sekä sisällön laatua että tekoälyn toimintaa.",
-    "modal-header": "Annoit peukun alas",
-    "modal-placeholder": "Esim. sisältö epätarkkaa, ei vastannut tarvetta, väärä sävy…",
-    "toast": "Kiitos palautteestasi!"
+    "modal": {
+      "body": "Et ollut tyytyväinen. Voisitko kertoa tarkemmin, mikä ei toiminut? Palautteesi auttaa meitä kehittämään sekä sisällön laatua että tekoälyn toimintaa.",
+      "close": "Sulje",
+      "header": "Tarkenna palautettasi",
+      "placeholder": "Esim. sisältö epätarkkaan, ei vastannut tarvetta, väärä sävy",
+      "send": "Lähetä"
+    },
+    "toast": "Kiitos palautteesta!"
   },
   "remove-approval": "Hylkää hyväksyntä",
   "remove-favorite": "Poista suosikeista",


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Update RateAiContent modal's content
- Fix a11y issues; was not usable with the keyboard and therefore not with a screenreader
  - Use button instead of svg as an button
  - Add aria labels for buttons to tell what those are
  - Add explanation for the icon, as it seems informative in this case
- Add Toasts when feedback is sent
- Update to show only in **dev**

## Notes
`description` prop in ConfirmDialog only supports text so therefore it did not seem possible at this time to get it correctly to change lines / separate paragraphs as in design.
--> creating ticket to backlog


## Screenshots

### Updated modal
<img width="400" alt="SCR-20250924-luan" src="https://github.com/user-attachments/assets/49f81379-1f81-49d7-ac56-94c3c580ec2a" />

### Able to use keyboard
<img width="400"  alt="SCR-20250924-lubu" src="https://github.com/user-attachments/assets/13042a97-de32-4ea9-9f01-e531eea165dc" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2222
