### PR TITLE
OPHJOD-2296: Fix LanguageButton & UserButton overlapping NoteStack

### DIFF
--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -35,7 +35,12 @@ export const LanguageButton = ({ onClick, langMenuOpen, menuRef, onMenuBlur, onM
         {carets}
       </button>
       {langMenuOpen && (
-        <div ref={menuRef} onBlur={onMenuBlur} className="absolute right-0 translate-y-8" data-testid="language-menu">
+        <div
+          ref={menuRef}
+          onBlur={onMenuBlur}
+          className="z-60 absolute right-0 translate-y-8"
+          data-testid="language-menu"
+        >
           <LanguageMenu onClick={onMenuClick} />
         </div>
       )}

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -46,7 +46,11 @@ export const UserButton = ({ onLogout, onClick }: UserButtonProps) => {
         {carets}
       </button>
       {userMenuOpen && (
-        <div ref={userMenuRef} className="absolute right-0 min-w-max translate-y-8 transform" data-testid="user-menu">
+        <div
+          ref={userMenuRef}
+          className="z-60 absolute right-0 min-w-max translate-y-8 transform"
+          data-testid="user-menu"
+        >
           <PopupList classNames="gap-2">
             <NavLink
               to={userMenuProfileFrontUrl}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fix LanguageButton & UserButton menus overlapping with the NoteStack

## Screenshot

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/a02603fb-603f-4cbb-996b-7f33e291f7f1" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2296
