### PR TITLE
OPHJOD-2011: Fix the removal of imported kiinnostukset in tool and remove confirm dialogs

### DIFF
--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -1049,14 +1049,6 @@
         },
         "textarea-placeholder": "Kerro omin sanoin mahdollisimman kuvailevasti mitä sinä jo osaat"
       },
-      "delete-imported": {
-        "description": "Haluatko varmasti tyhjentää valitut profiilista tuodut osaamiset ja kiinnostukset?",
-        "title": "Tyhjennä profiilista tuodut osaamiset"
-      },
-      "delete-mapped": {
-        "description": "Haluatko varmasti tyhjentää valitut kartoitetut osaamiset ja kiinnostukset?",
-        "title": "Tyhjennä kartoitetut osaamiset"
-      },
       "description": "Saat ehdotuksia osaamisista ja kiinnostuksista tekstin pohjalta. Valitse sopivat. Oikealla näkyvä lista perustuu valintoihisi.",
       "export": {
         "confirm-button": "Tallenna profiiliin",

--- a/src/routes/Tool/CategorizedCompetenceTagList.tsx
+++ b/src/routes/Tool/CategorizedCompetenceTagList.tsx
@@ -1,6 +1,5 @@
 import AddedTags from '@/components/OsaamisSuosittelija/AddedTags';
 import type { OsaaminenValue } from '@/components/OsaamisSuosittelija/OsaamisSuosittelija';
-import { useModal } from '@/hooks/useModal';
 import type { OsaaminenLahdeTyyppi } from '@/routes/types';
 import { useToolStore } from '@/stores/useToolStore';
 import { Button, EmptyState } from '@jod/design-system';
@@ -97,7 +96,6 @@ const CategorizedCompetenceTagList = () => {
   const combinedData = [...osaamiset, ...kiinnostukset];
   const hasProfileCompetences = combinedData.filter((o) => o.tyyppi && profileTypes.includes(o.tyyppi)).length > 0;
   const hasOtherData = osaamisetVapaateksti?.[language] || kiinnostuksetVapaateksti?.[language];
-  const { showDialog } = useModal();
 
   return (
     <div className="flex flex-col">
@@ -115,14 +113,8 @@ const CategorizedCompetenceTagList = () => {
             <Button
               variant="plain"
               onClick={() => {
-                showDialog({
-                  title: t('tool.my-own-data.delete-mapped.title'),
-                  description: t('tool.my-own-data.delete-mapped.description'),
-                  onConfirm: () => {
-                    setOsaamiset(osaamiset.filter((o) => o.tyyppi !== 'KARTOITETTU'));
-                    setKiinnostukset(kiinnostukset.filter((o) => o.tyyppi !== 'KARTOITETTU'));
-                  },
-                });
+                setOsaamiset(osaamiset.filter((o) => o.tyyppi !== 'KARTOITETTU'));
+                setKiinnostukset(kiinnostukset.filter((o) => o.tyyppi !== 'KARTOITETTU'));
               }}
               label={t('delete')}
             />
@@ -144,25 +136,17 @@ const CategorizedCompetenceTagList = () => {
                 <CompetenceCategory
                   key={type}
                   osaamiset={combinedData.filter(filterByType(type))}
-                  onChange={removeOsaaminen}
+                  onChange={type === 'KIINNOSTUS' ? removeKiinnostus : removeOsaaminen}
                 />
               </div>
             ))}
           <Button
             variant="plain"
             onClick={() => {
-              showDialog({
-                title: t('tool.my-own-data.delete-imported.title'),
-                description: t('tool.my-own-data.delete-imported.description'),
-                onConfirm: () => {
-                  setOsaamiset(
-                    osaamiset.filter((o) => o.tyyppi && ![...profileTypes, 'KIINNOSTUS'].includes(o.tyyppi)),
-                  );
-                  setKiinnostukset(
-                    kiinnostukset.filter((o) => o.tyyppi && ![...profileTypes, 'KIINNOSTUS'].includes(o.tyyppi)),
-                  );
-                },
-              });
+              setOsaamiset(osaamiset.filter((o) => o.tyyppi && ![...profileTypes, 'KIINNOSTUS'].includes(o.tyyppi)));
+              setKiinnostukset(
+                kiinnostukset.filter((o) => o.tyyppi && ![...profileTypes, 'KIINNOSTUS'].includes(o.tyyppi)),
+              );
             }}
             label={t('delete')}
           />


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Fix the removal of imported kiinnostukset in tool
* In the linked ticket it says that there should be a confirmation dialog when removing free texts that are imported from profile. When I asked about the texts from design, they said that there is no need for the dialogs and the previous ones should also be removed... For now.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2011
