### PR TITLE
OPHJOD-1917: Fix the wrong type of competence being imported in tool

### DIFF
--- a/src/routes/Tool/ProfileImportExport.tsx
+++ b/src/routes/Tool/ProfileImportExport.tsx
@@ -177,9 +177,9 @@ const CompetenceImport = () => {
         .filter((osaaminen) => {
           return mappedSelectedCompetences.some((msc) => {
             if (msc.tyyppi === 'MUU_OSAAMINEN') {
-              return msc.id.includes(osaaminen.osaaminen.uri);
+              return msc.id.includes(osaaminen.osaaminen.uri) && osaaminen.lahde.tyyppi === 'MUU_OSAAMINEN';
             } else if (osaaminen.lahde.id) {
-              return msc.id.includes(osaaminen.lahde.id);
+              return msc.id.includes(osaaminen.lahde.id) && msc.tyyppi === osaaminen.lahde.tyyppi;
             }
             return false;
           });


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

Fix the wrong type of competence being imported in tool, in the case where the user has the same competence under different types/categories


<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1917
