### PR TITLE
OPHJOD-2397: Fix mobile styles for job opportunity salary information

### DIFF
--- a/src/routes/JobOpportunity/JobOpportunity.tsx
+++ b/src/routes/JobOpportunity/JobOpportunity.tsx
@@ -113,33 +113,33 @@ const JobOpportunity = () => {
                 {formatDate(new Date(tyomahdollisuus?.palkkatiedot?.tiedotHaettu), 'medium')}
               </p>
 
-              <div className="flex justify-around text-center gap-11 my-8">
+              <div className="flex sm:flex-row flex-col justify-around text-center gap-9 sm:my-8 my-4">
                 <div>
-                  <h2 className="font-bold text-heading-1">
-                    {tyomahdollisuus?.palkkatiedot?.alinDesiiliPalkka || '--'} €
+                  <h2 className="sm:text-heading-1 text-heading-1-mobile text-accent">
+                    {tyomahdollisuus?.palkkatiedot?.alinDesiiliPalkka || '---'} €
                   </h2>
-                  <p className="mb-1 text-secondary-gray">{t('job-opportunity.salary-data.lowest-decile')}</p>
+                  <p>{t('job-opportunity.salary-data.lowest-decile')}</p>
                 </div>
 
                 <div>
-                  <h2 className="font-bold text-heading-1">
-                    {tyomahdollisuus?.palkkatiedot?.mediaaniPalkka || '--'} €
+                  <h2 className="sm:text-heading-1 text-heading-1-mobile text-accent">
+                    {tyomahdollisuus?.palkkatiedot?.mediaaniPalkka || '---'} €
                   </h2>
-                  <p className="mb-1 text-secondary-gray">{t('job-opportunity.salary-data.median')}</p>
+                  <p>{t('job-opportunity.salary-data.median')}</p>
                 </div>
 
                 <div>
-                  <h2 className="font-bold text-heading-1">
-                    {tyomahdollisuus?.palkkatiedot?.ylinDesiiliPalkka || '--'} €
+                  <h2 className="sm:text-heading-1 text-heading-1-mobile text-accent">
+                    {tyomahdollisuus?.palkkatiedot?.ylinDesiiliPalkka || '---'} €
                   </h2>
-                  <p className="mb-1 text-secondary-gray">{t('job-opportunity.salary-data.highest-decile')}</p>
+                  <p>{t('job-opportunity.salary-data.highest-decile')}</p>
                 </div>
               </div>
 
-              <p className="m-0 text-secondary-gray">{t('job-opportunity.salary-data.description')}</p>
+              <p>{t('job-opportunity.salary-data.description')}</p>
             </>
           ) : (
-            <p className="text-secondary-gray">{t('job-opportunity.salary-data.not-available')}</p>
+            <p>{t('job-opportunity.salary-data.not-available')}</p>
           )}
         </div>
       ),


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Fixed mobile view for salary info in job opportunity, the salaries now stack vertically on mobile
* Cleaned and updated some styles, like font colors so it's a bit closer to the design.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2397

<img width="308" height="647" alt="image" src="https://github.com/user-attachments/assets/9cd35849-d5d3-41e4-9acc-9fa2decb9a4e" />
