### PR TITLE
OPHJOD-3307: Update DS to fix tooltip cutoff and overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260410-1/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260414-1/jod-design-system-0.0.0.tgz",
         "driver.js": "1.4.0",
         "i18next": "25.10.10",
         "i18next-http-backend": "3.0.4",
@@ -1088,8 +1088,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260410-1/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-9VMo7nM25B5vGzgElp+ADnXMDjOdjr0vCROBpPtbn8WgvHiq9saus4spZr0YcQLmThgzZ5su6gLZnqW7/bP5cg==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260414-1/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-+CcmRpe9FXImeJndi7XIr+BGv0hF/Lzp5eIZDQfjwZkQpO1zS8NHB1tNWfYsvbydTp02o/3oT5GTgkf1jSZQRw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260410-1/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260414-1/jod-design-system-0.0.0.tgz",
     "driver.js": "1.4.0",
     "i18next": "25.10.10",
     "i18next-http-backend": "3.0.4",

--- a/src/components/HowToUse/HowToUse.tsx
+++ b/src/components/HowToUse/HowToUse.tsx
@@ -129,14 +129,6 @@ export function HowToUse() {
   const createProfileId = React.useId();
   const findWithWordsId = React.useId();
   const { osaamispolkuLogo, opintopolkuLogo, tyomarkkinatoriLogo } = getLocalizedLogos(language);
-  const tooltipPortalRef = React.useRef<HTMLDivElement>(null);
-  const [portalRoot, setPortalRoot] = React.useState<HTMLElement | null>(null);
-
-  React.useEffect(() => {
-    if (tooltipPortalRef.current) {
-      setPortalRoot(tooltipPortalRef.current);
-    }
-  }, []);
 
   return (
     <figure className="flex flex-col justify-center items-center">
@@ -148,16 +140,13 @@ export function HowToUse() {
               / {t('common:navigation.external.yksilo.label')}
             </div>
           </div>
-          <div
-            className="bg-secondary-1-dark rounded-md p-5 text-white text-body-sm font-semibold flex items-center justify-center"
-            ref={tooltipPortalRef}
-          >
+          <div className="bg-secondary-1-dark rounded-md p-5 text-white text-body-sm font-semibold flex items-center justify-center">
             <span className="mr-3">{t('how-to-use.find-opportunities-title')}</span>
             <Tooltip>
               <TooltipTrigger aria-label={t('common:more-info')} aria-describedby={findOpportunitiesId}>
                 <JodInfo />
               </TooltipTrigger>
-              <TooltipContent id={findOpportunitiesId} portalRoot={portalRoot}>
+              <TooltipContent id={findOpportunitiesId}>
                 <p className="font-bold mb-2">{t('how-to-use.find-opportunities-title')}</p>
                 <p className="mb-3">{t('how-to-use.find-opportunities-description')}</p>
                 <p className="mb-2">{t('how-to-use.find-opportunities-disclaimer')}</p>


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Update DS to fix tooltip cutoff and overflow
* This update also fixed letters cutting off from the bottom in tags

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3307
