### PR TITLE
OPHJOD-3250: Improve mobile filters in search page

### DIFF
--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -907,7 +907,8 @@
   "search": {
     "clear": "Clear search",
     "description": "You can search for opportunities using free text search. You can influence the visibility of results by filtering the list.",
-    "filters": "Filters",
+    "filters": "Filters ({{count}})",
+    "filters_zero": "Filters",
     "global-placeholder": "Search opportunities",
     "label": "Search opportunities",
     "no-results": "No results found for the search term.",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -905,7 +905,8 @@
   "search": {
     "clear": "Tyhjennä haku",
     "description": "Voit hakea mahdollisuuksia käyttämällä vapaasanahakua. Tulosten näkyvyyteen voit vaikuttaa suodattamalla listaa.",
-    "filters": "Suodattimet",
+    "filters": "Suodattimet ({{count}})",
+    "filters_zero": "Suodattimet",
     "global-placeholder": "Hae mahdollisuuksia",
     "label": "Hae mahdollisuuksia",
     "no-results": "Hakusanalla ei löytynyt tuloksia.",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -906,7 +906,8 @@
   "search": {
     "clear": "Rensa sökning",
     "description": "Du kan söka efter möjligheter med hjälp av fritextsökning. Du kan påverka synligheten av resultaten genom att filtrera listan.",
-    "filters": "Filter",
+    "filters": "Filter ({{count}})",
+    "filters_zero": "Filter",
     "global-placeholder": "Sök möjligheter",
     "label": "Sök möjligheter",
     "no-results": "Inga resultat hittades för sökordet.",

--- a/src/routes/Search/Results.tsx
+++ b/src/routes/Search/Results.tsx
@@ -28,6 +28,10 @@ export const SearchResults = ({ scrollRef }: { scrollRef: React.RefObject<HTMLDi
   const paginationTranslations = usePaginationTranslations();
   const statusText = isLoading ? t('tool.updating') : t('tool.opportunities-loaded', { count: filteredResults.length });
 
+  const resultsCountText = lg
+    ? t('search.results-found', { count: filteredMetadata.length })
+    : t('search.results-found-short', { count: filteredMetadata.length });
+
   return (
     <section aria-busy={isLoading}>
       <output aria-live="polite" className="sr-only">
@@ -39,15 +43,18 @@ export const SearchResults = ({ scrollRef }: { scrollRef: React.RefObject<HTMLDi
           <OpportunityCardSkeleton />
         </div>
       )}
-      {!isLoading && filteredResults.length === 0 && <EmptyState text={t('search.no-results')} />}
+      <div className="pb-5 font-arial flex justify-between items-center gap-3">
+        {!isLoading && (
+          <>
+            {filteredResults.length === 0 && <EmptyState text={t('search.no-results')} />}
+            {filteredResults.length > 0 && <span className="h-8 flex items-center">{resultsCountText}</span>}
+          </>
+        )}
+        {!lg && <SearchFilters />}
+      </div>
+
       {!isLoading && filteredResults.length > 0 && (
         <div className="flex flex-col">
-          <div className="pb-5 font-arial flex justify-between items-center">
-            {lg
-              ? t('search.results-found', { count: filteredMetadata.length })
-              : t('search.results-found-short', { count: filteredMetadata.length })}
-            {!lg && <SearchFilters />}
-          </div>
           <ul
             id="search-your-opportunities-list"
             className="flex flex-col gap-5 sm:gap-3 mb-8"

--- a/src/routes/Search/SearchFilters.tsx
+++ b/src/routes/Search/SearchFilters.tsx
@@ -13,10 +13,10 @@ const FiltersModal = ({ onClose, ...rest }: ModalComponentProps) => {
     <Modal
       {...rest}
       open={rest.open && !lg}
-      topSlot={<span className="sm:text-heading-2 text-heading-2-mobile">{t('search.filters')}</span>}
+      topSlot={<span className="sm:text-heading-2 text-heading-2-mobile">{t('search.filters', { count: 0 })}</span>}
       className="h-fit!"
       content={
-        <div className="p-5 md:px-8 md:ml-3">
+        <div className="p-5 pb-6 md:px-8 md:ml-3">
           <FiltersContent />
         </div>
       }
@@ -25,7 +25,7 @@ const FiltersModal = ({ onClose, ...rest }: ModalComponentProps) => {
           <Button size={sm ? 'lg' : 'sm'} onClick={onClose} label={t('close')} variant="accent" />
         </div>
       }
-      name={t('search.filters')}
+      name={t('search.filters', { count: 0 })}
     />
   );
 };
@@ -70,7 +70,7 @@ const FiltersContent = () => {
           <Checkbox
             name={filterKey}
             value={filterKey}
-            className="font-poppins! gap-4 items-center"
+            className="gap-4 items-center"
             checked={filters[filterKey as keyof typeof filters]}
             label={getCheckboxLabel(filterKey as keyof typeof filters)}
             ariaLabel={translations[filterKey as keyof typeof filters]}
@@ -89,11 +89,13 @@ export const SearchFilters = () => {
   const { t } = useTranslation();
   const { showModal } = useModal();
   const { lg } = useMediaQueries();
+  const filters = useSearchStore((state) => state.filters);
+  const filtersCount = Object.values(filters).filter((value) => value === true).length;
 
   if (lg) {
     return (
       <div className="bg-white rounded-md p-6 flex flex-col select-none gap-6">
-        <h2 className="sm:text-body-sm text-body-sm-mobile">{t('search.filters')}</h2>
+        <h2 className="sm:text-body-sm text-body-sm-mobile">{t('search.filters', { count: 0 })}</h2>
         <FiltersContent />
       </div>
     );
@@ -104,7 +106,7 @@ export const SearchFilters = () => {
       variant="white"
       ariaHaspopup="dialog"
       onClick={() => showModal(FiltersModal)}
-      label={t('search.filters')}
+      label={t('search.filters', { count: filtersCount })}
       icon={<JodSettings className="text-primary-gray" />}
       className="text-primary-gray!"
       iconSide="left"


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Filters button on mobile now stays visible when there are no results (the button disappeared before).
* Added a count to filters so that users might realize that there are no results due to filters
  * Ticket comment mentioned about using a specific text in case there are no filtered results, I tried it, but the UI looked quite sloppy with a longer text.
* Removed poppins font from checkboxes.
* Change filters modal bottom padding `16px` -> `24px`.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3250

<img width="502" height="306" alt="image" src="https://github.com/user-attachments/assets/e21b10da-4b34-407b-90c6-c4f32dccf660" />

