### PR TITLE
OPHJOD-3299: Initialize roving tabindex on conditionally rendered elements

### DIFF
--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -117,7 +117,15 @@ const CompetencesRow = ({
   sortedCompetences: ExperienceTableRowData['osaamiset'];
 }) => {
   const { t } = useTranslation();
-  const { ref, handleKeyDown } = useArrowKeyControls(sortedCompetences);
+  const { ref, handleKeyDown, initRovingTabindex } = useArrowKeyControls(sortedCompetences);
+
+  // Since tags are not visible by default, we need to initialize roving tabindex when they become visible.
+  React.useEffect(() => {
+    if (tagsVisibleState) {
+      initRovingTabindex();
+    }
+  }, [initRovingTabindex, tagsVisibleState]);
+
   return (
     <tr>
       {tagsVisibleState && !showCheckbox && (

--- a/src/hooks/useArrowKeyControls/index.ts
+++ b/src/hooks/useArrowKeyControls/index.ts
@@ -27,13 +27,17 @@ export const useArrowKeyControls = <T extends HTMLElement = HTMLUListElement>(it
     return elements;
   };
 
-  // Init roving tabindex on mount, run only once on mount.
-  React.useEffect(() => {
+  const initRovingTabindex = () => {
     const elements = getTagElements();
 
     elements.forEach((el, index) => {
       el.setAttribute('tabindex', index === activeIndex ? '0' : '-1');
     });
+  };
+
+  // Init roving tabindex on mount, run only once on mount.
+  React.useEffect(() => {
+    initRovingTabindex();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -101,5 +105,12 @@ export const useArrowKeyControls = <T extends HTMLElement = HTMLUListElement>(it
     }
   }, [lastClickedIndex, items.length, activeIndex]);
 
-  return { ref, handleKeyDown, activeIndex, setActiveIndex, setLastClickedIndex };
+  return {
+    ref,
+    handleKeyDown,
+    activeIndex,
+    setActiveIndex,
+    setLastClickedIndex,
+    initRovingTabindex,
+  };
 };

--- a/src/routes/Tool/VirtualAssistant.tsx
+++ b/src/routes/Tool/VirtualAssistant.tsx
@@ -283,7 +283,14 @@ export const VirtualAssistant = ({ type, className }: { type: 'competences' | 'i
     ref: selectedTagsRef,
     handleKeyDown: handleTagsKeyboardNavigation,
     setLastClickedIndex,
+    initRovingTabindex,
   } = useArrowKeyControls(selected);
+
+  React.useEffect(() => {
+    if (!isSelectedEmpty) {
+      initRovingTabindex();
+    }
+  }, [isSelectedEmpty, initRovingTabindex]);
 
   return (
     <div className={className}>


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
* Initialize roving tabindex on conditionally rendered elements.
  * Without initialization, when the element attached to ref renders, proper tab indexes wouldn't get set and tabbing would jump from tag to tag, until user pressed any arrow key once.

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3299
