### PR TITLE
OPHJOD-3327: Fix mobile filter modal in profile favorites

### DIFF
--- a/src/components/FilterList/FilterList.tsx
+++ b/src/components/FilterList/FilterList.tsx
@@ -28,7 +28,7 @@ export const FilterList = ({
             </TitleTag>
           }
         >
-          <section aria-labelledby={id} id={id}>
+          <section className="pt-4" aria-labelledby={id} id={id}>
             {children}
           </section>
         </Accordion>

--- a/src/routes/Profile/Favorites/Favorites.tsx
+++ b/src/routes/Profile/Favorites/Favorites.tsx
@@ -235,9 +235,9 @@ const Favorites = () => {
             name={t('filters')}
             open={showFilters}
             onClose={() => setShowFilters(false)}
+            topSlot={<span className="sm:text-heading-2 text-heading-2-mobile">{t('content')}</span>}
             content={
-              <div className="py-6 bg-bg-gray px-5 md:px-9 ml-[20px]">
-                <span className="text-heading-3">{t('content')}</span>
+              <div className="bg-bg-gray py-3 ml-5">
                 <MahdollisuusTyyppiFilter
                   jobFilterText={jobFilterText}
                   educationFilterText={educationFilterText}
@@ -249,7 +249,7 @@ const Favorites = () => {
             footer={
               <div className="flex flex-row justify-end gap-4 flex-1">
                 <Button
-                  variant="white"
+                  variant="accent"
                   label={t('close')}
                   onClick={() => setShowFilters(false)}
                   className="whitespace-nowrap"

--- a/src/routes/Profile/Preferences/PersonalDetails/PersonalDetails.tsx
+++ b/src/routes/Profile/Preferences/PersonalDetails/PersonalDetails.tsx
@@ -172,6 +172,7 @@ const PersonalDetails = () => {
             <InputField
               id={emailFieldId}
               hideLabel
+              requiredText={t('common:required')}
               value={email}
               placeholder="matti.meikalainen@suomi.fi"
               errorMessage={emailValid === false ? formErrorMessage.email().message : ''}

--- a/src/routes/Profile/WelcomePathModal/WelcomePathModal.tsx
+++ b/src/routes/Profile/WelcomePathModal/WelcomePathModal.tsx
@@ -105,6 +105,7 @@ const StepInformation = ({ data }: { data: YksiloData }) => {
           interactiveComponent={
             <InputField
               {...register('email')}
+              requiredText={t('common:required')}
               id={emailFieldId}
               hideLabel={true}
               placeholder="matti.meikalainen@suomi.fi"


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Small UI improvements to filters in mobile and desktop.
<img width="390" height="710" alt="Screenshot 2026-04-14 at 15 23 12" src="https://github.com/user-attachments/assets/df51ce46-c206-4671-8f8d-26e8b1ec8bb4" />
<img width="361" height="167" alt="Screenshot 2026-04-14 at 15 34 25" src="https://github.com/user-attachments/assets/350be377-e72b-44e9-b624-6d993c36a0eb" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3327
