### PR TITLE
OPHJOD-3332: Update e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,23 +63,19 @@ jobs:
       - name: Run build
         run: npm run build
 
-      # E2E tests
-      # Disabled for now, as they are not yet implemented.
-      # It's not recommended to cache browsers.
-      # See https://playwright.dev/docs/ci#caching-browsers
-      # - name: Install Playwright browsers
-      #   run: npx playwright install --with-deps
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
 
-      # - name: Run Playwright e2e tests
-      #   run: npx playwright test
+      - name: Run Playwright e2e tests
+        run: npx playwright test
 
-      # - name: Upload Playwright report
-      #   uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-      #   if: always()
-      #   with:
-      #     name: playwright-report
-      #     path: playwright-report/
-      #     retention-days: 30
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7

--- a/e2e/EducationHistoryWizard.spec.ts
+++ b/e2e/EducationHistoryWizard.spec.ts
@@ -1,22 +1,33 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import {
   educationCompetences,
   educationHistory,
   educationHistoryItem,
   suggestedEducationCompetences,
 } from './fixtures';
-import { mockAuthenticatedUser, mockProfileWizard, mockSelectedCompetences, mockSuggestedCompetences } from './mocks';
+import {
+  mockAuthenticatedUser,
+  mockFeatureFlags,
+  mockProfileWizard,
+  mockRedundantEndpoints,
+  mockSelectedCompetences,
+  mockSuggestedCompetences,
+} from './mocks';
 
-async function mockEducationHistory(page: Page, data = educationHistory) {
-  await mockProfileWizard(page, 'koulutuskokonaisuudet', data);
-}
-
-test('add new education', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
+  await mockRedundantEndpoints(page);
+  await mockFeatureFlags(page);
   await mockAuthenticatedUser(page);
-  await mockEducationHistory(page, []);
+  await mockSuggestedCompetences(page, suggestedEducationCompetences, educationCompetences);
+  await mockSelectedCompetences(page, educationCompetences);
+  await mockProfileWizard(page, 'koulutuskokonaisuudet', educationHistory);
 
   await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/koulutukseni');
+  await page.getByText('Hyväksy kaikki').click();
+});
 
+test('add new education', async ({ page, isMobile }) => {
+  await mockProfileWizard(page, 'koulutuskokonaisuudet', []);
   // Open wizard
   await page.getByRole('button', { name: 'Lisää uusi koulutus' }).click();
 
@@ -24,14 +35,13 @@ test('add new education', async ({ page }) => {
   await page.getByLabel('Oppilaitos tai koulutuksen järjestäjä').fill('Iso Opisto');
   await page.getByLabel('Tutkinnon tai koulutuksen nimi').fill('Oppilas');
   await page.getByLabel('Alkoi').fill('01.01.2001');
+  await page.getByLabel('Vapaamuotoinen kuvaus').fill('Koulutuksen kuvaus');
 
   await page.keyboard.press('Tab');
   await page.locator('button[aria-label*="Seuraava"]').click();
 
   // "Tunnista osaamisia" step
-  await mockSuggestedCompetences(page, suggestedEducationCompetences, educationCompetences);
-  await mockSelectedCompetences(page, educationCompetences);
-  await page.getByLabel('Tunnista osaamisia').fill('opetus');
+  await page.getByRole('textbox', { name: 'Tunnista osaamisia' }).fill('opetus');
 
   await page.getByRole('button', { name: 'opetussuunnitelman tavoitteet' }).click();
   await page.getByRole('button', { name: 'arviointiprosessit' }).click();
@@ -40,9 +50,23 @@ test('add new education', async ({ page }) => {
   await page.locator('button[aria-label*="Seuraava"]').click();
 
   // "Yhteenveto" step
-  await expect(page.getByText('Iso Opisto')).toBeVisible();
-  await expect(page.getByText('Oppilas')).toBeVisible();
-  await expect(page.getByText('3 osaamista')).toHaveCount(2);
+  const rows = page.getByTestId('education-history-summary-table').locator('tbody tr');
+  if (isMobile) {
+    await expect(rows.nth(0).locator('td').nth(0)).toContainText('Iso Opisto');
+    await expect(rows.nth(0).locator('td').nth(0)).toContainText('1/2001');
+    await expect(rows.nth(0).locator('td').nth(1)).toHaveText('3');
+  } else {
+    await expect(rows.nth(0).locator('td').nth(0)).toHaveText('Iso Opisto');
+    await expect(rows.nth(0).locator('td').nth(1)).toHaveText('1/2001');
+    await expect(rows.nth(0).locator('td').nth(2)).toBeEmpty();
+    await expect(rows.nth(0).locator('td').nth(3)).toHaveText('3');
+
+    // Second row is for osaamiset when they are uncollapsed, so we check the third row
+    await expect(rows.nth(2).locator('td').nth(0)).toHaveText('Oppilas');
+    await expect(rows.nth(2).locator('td').nth(1)).toHaveText('1/2001');
+    await expect(rows.nth(2).locator('td').nth(2)).toBeEmpty();
+    await expect(rows.nth(2).locator('td').nth(3)).toHaveText('3');
+  }
 
   const requestPromise = page.waitForRequest(
     (request) => request.url().includes('/api/profiili/koulutuskokonaisuudet') && request.method() === 'POST',
@@ -54,34 +78,27 @@ test('add new education', async ({ page }) => {
 });
 
 test('delete educationHistory item', async ({ page }) => {
-  await mockAuthenticatedUser(page);
-  await mockEducationHistory(page);
-
-  await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/koulutukseni');
-
   // Edit the first item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
   await page.getByRole('button', { name: 'Poista koulutus' }).click();
+  const confirmButton = page.locator('button.ds\\:bg-alert', { hasText: 'Poista koulutus' }).last();
+  await expect(confirmButton).toBeVisible();
 
-  const deleteRequestPromise = page.waitForRequest(
-    (request) => request.url().includes('/api/profiili/koulutuskokonaisuudet') && request.method() === 'DELETE',
-  );
-  await page.getByRole('button', { name: 'Poista koulutus' }).click();
-  const request = await deleteRequestPromise;
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (request) => request.url().includes('/api/profiili/koulutuskokonaisuudet') && request.method() === 'DELETE',
+    ),
+    confirmButton.click(),
+  ]);
+
   const expectedId = educationHistory[0].id;
   expect(request.url()).toContain('/api/profiili/koulutuskokonaisuudet/');
   expect(request.url()).toContain(expectedId);
 });
 
 test('edit educationHistory item', async ({ page }) => {
-  await mockAuthenticatedUser(page);
-  await mockEducationHistory(page);
-
-  await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/koulutukseni');
-
   // Edit the first item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
-
   await page.getByLabel('Oppilaitos tai koulutuksen järjestäjä').fill('Opisto');
 
   const requestPromise = page.waitForRequest(

--- a/e2e/FreeTimeActivitiesWizard.spec.ts
+++ b/e2e/FreeTimeActivitiesWizard.spec.ts
@@ -1,22 +1,33 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import {
   freetimeActivities,
   freetimeActivityItem,
   freetimeCompetences,
   suggestedFreetimeCompetences,
 } from './fixtures';
-import { mockAuthenticatedUser, mockProfileWizard, mockSelectedCompetences, mockSuggestedCompetences } from './mocks';
+import {
+  mockAuthenticatedUser,
+  mockFeatureFlags,
+  mockProfileWizard,
+  mockRedundantEndpoints,
+  mockSelectedCompetences,
+  mockSuggestedCompetences,
+} from './mocks';
 
-async function mockFreetimeActivities(page: Page, data = freetimeActivities) {
-  await mockProfileWizard(page, 'vapaa-ajan-toiminnot', data);
-}
-
-test('add new freetime activity', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
+  await mockRedundantEndpoints(page);
+  await mockFeatureFlags(page);
   await mockAuthenticatedUser(page);
-  await mockFreetimeActivities(page, []);
+  await mockSuggestedCompetences(page, suggestedFreetimeCompetences, freetimeCompetences);
+  await mockSelectedCompetences(page, freetimeCompetences);
+  await mockProfileWizard(page, 'vapaa-ajan-toiminnot', freetimeActivities);
 
   await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/vapaa-ajan-toimintoni');
+  await page.getByText('Hyväksy kaikki').click();
+});
 
+test('add new freetime activity', async ({ page, isMobile }) => {
+  await mockProfileWizard(page, 'vapaa-ajan-toiminnot', []);
   // Open wizard
   await page.getByRole('button', { name: 'Lisää uusi vapaa-ajan toiminto' }).click();
 
@@ -25,14 +36,13 @@ test('add new freetime activity', async ({ page }) => {
   await page.getByLabel('Vapaa-ajan toiminnon nimi').fill('Uima-altaan testaus');
   await page.getByLabel('Alkoi').fill('01.07.2001');
   await page.getByLabel('Loppui').fill('30.07.2001');
+  await page.getByLabel('Vapaamuotoinen kuvaus').fill('Toiminnon kuvaus');
 
   await page.keyboard.press('Tab');
   await page.locator('button[aria-label*="Seuraava"]').click();
 
   // "Tunnista osaamisia"
-  await mockSuggestedCompetences(page, suggestedFreetimeCompetences, freetimeCompetences);
-  await mockSelectedCompetences(page, freetimeCompetences);
-  await page.getByLabel('Tunnista osaamisia').fill('uida');
+  await page.getByRole('textbox', { name: 'Tunnista osaamisia' }).fill('uida');
 
   await page.getByRole('button', { name: 'uida' }).click();
   await page.getByRole('button', { name: 'selviytyä merellä tilanteessa, jossa laiva joudutaan jättämään' }).click();
@@ -41,9 +51,24 @@ test('add new freetime activity', async ({ page }) => {
   await page.locator('button[aria-label*="Seuraava"]').click();
 
   // "Yhteenveto"
-  await expect(page.getByText('Testaaminen')).toBeVisible();
-  await expect(page.getByText('Uima-altaan testaus')).toBeVisible();
-  await expect(page.getByText('3 osaamista')).toHaveCount(2);
+  const rows = page.getByTestId('free-time-summary-table').locator('tbody tr');
+
+  if (isMobile) {
+    await expect(rows.nth(0).locator('td').nth(0)).toContainText('Testaaminen');
+    await expect(rows.nth(0).locator('td').nth(0)).toContainText('7/2001');
+    await expect(rows.nth(0).locator('td').nth(1)).toHaveText('3');
+  } else {
+    await expect(rows.nth(0).locator('td').nth(0)).toHaveText('Testaaminen');
+    await expect(rows.nth(0).locator('td').nth(1)).toHaveText('7/2001');
+    await expect(rows.nth(0).locator('td').nth(2)).toHaveText('7/2001');
+    await expect(rows.nth(0).locator('td').nth(3)).toHaveText('3');
+
+    // Second row is for osaamiset when they are uncollapsed, so we check the third row
+    await expect(rows.nth(2).locator('td').nth(0)).toHaveText('Uima-altaan testaus');
+    await expect(rows.nth(2).locator('td').nth(1)).toHaveText('7/2001');
+    await expect(rows.nth(2).locator('td').nth(2)).toHaveText('7/2001');
+    await expect(rows.nth(2).locator('td').nth(3)).toHaveText('3');
+  }
 
   const requestPromise = page.waitForRequest(
     (request) => request.url().includes('/api/profiili/vapaa-ajan-toiminnot') && request.method() === 'POST',
@@ -55,31 +80,24 @@ test('add new freetime activity', async ({ page }) => {
 });
 
 test('delete freetime activity item', async ({ page }) => {
-  await mockAuthenticatedUser(page);
-  await mockFreetimeActivities(page);
-
-  await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/vapaa-ajan-toimintoni');
-
   // Edit the first item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
-  await page.getByRole('button', { name: 'Poista vapaa-ajan toiminto' }).click();
+  await page.getByRole('button', { name: 'Poista toiminto' }).click();
+  const confirmButton = page.locator('button.ds\\:bg-alert', { hasText: 'Poista' }).last();
+  await expect(confirmButton).toBeVisible();
 
-  const deleteRequestPromise = page.waitForRequest(
-    (request) => request.url().includes('/api/profiili/vapaa-ajan-toiminnot') && request.method() === 'DELETE',
-  );
-  await page.getByRole('button', { name: 'Poista' }).click();
-  const request = await deleteRequestPromise;
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (request) => request.url().includes('/api/profiili/vapaa-ajan-toiminnot') && request.method() === 'DELETE',
+    ),
+    confirmButton.click(),
+  ]);
   const expectedId = freetimeActivities[0].id;
   expect(request.url()).toContain('/api/profiili/vapaa-ajan-toiminnot/');
   expect(request.url()).toContain(expectedId);
 });
 
 test('edit freetime activity item', async ({ page }) => {
-  await mockAuthenticatedUser(page);
-  await mockFreetimeActivities(page);
-
-  await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/vapaa-ajan-toimintoni');
-
   // Edit the first item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
 

--- a/e2e/WorkHistoryWizard.spec.ts
+++ b/e2e/WorkHistoryWizard.spec.ts
@@ -1,33 +1,43 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { competences, suggestedCompetences, workHistory, workHistoryItem } from './fixtures';
-import { mockAuthenticatedUser, mockProfileWizard, mockSelectedCompetences, mockSuggestedCompetences } from './mocks';
+import {
+  mockAuthenticatedUser,
+  mockFeatureFlags,
+  mockProfileWizard,
+  mockRedundantEndpoints,
+  mockSelectedCompetences,
+  mockSuggestedCompetences,
+} from './mocks';
 
-async function mockWorkHistory(page: Page, data = workHistory) {
-  await mockProfileWizard(page, 'tyopaikat', data);
-}
-
-test('add new workhistory', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
+  await mockRedundantEndpoints(page);
+  await mockFeatureFlags(page);
   await mockAuthenticatedUser(page);
-  await mockWorkHistory(page, []);
+  await mockSelectedCompetences(page, competences);
+  await mockSuggestedCompetences(page, suggestedCompetences, competences);
+  await mockProfileWizard(page, 'tyopaikat', workHistory);
 
   await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/tyopaikkani');
+  await page.getByText('Hyväksy kaikki').click();
+});
 
+test('add new workhistory', async ({ page, isMobile }) => {
+  await mockProfileWizard(page, 'tyopaikat', []);
   // Open wizard
   await page.getByRole('button', { name: 'Lisää uusi työpaikka' }).click();
 
   // "Lisää uusi työpaikka" step
   await page.getByLabel('Työnantaja').fill('Testi Oy');
-  await page.getByLabel('Toimenkuva').fill('Testaaja');
+  await page.getByRole('textbox', { name: 'Toimenkuva' }).fill('Testaaja');
   await page.getByLabel('Alkoi').fill('01.01.2001');
+  await page.getByLabel('Vapaamuotoinen kuvaus').fill('Työpaikan kuvaus');
 
   await page.keyboard.press('Tab');
 
   await page.locator('button[aria-label*="Seuraava"]').click();
 
   // "Tunnista osaamisia" step
-  await mockSuggestedCompetences(page, suggestedCompetences, competences);
-  await mockSelectedCompetences(page, competences);
-  await page.getByLabel('Tunnista osaamisia').fill('kissa');
+  await page.getByRole('textbox', { name: 'Tunnista osaamisia' }).fill('kissa');
 
   await page.getByRole('button', { name: 'arvioida eläinten käyttäytymistä' }).click();
   await page.getByRole('button', { name: 'eläinten anatomia' }).click();
@@ -36,9 +46,24 @@ test('add new workhistory', async ({ page }) => {
   await page.locator('button[aria-label*="Seuraava"]').click();
 
   // "Yhteenveto" step
-  await expect(page.getByText('Testi Oy')).toBeVisible();
-  await expect(page.getByText('Testaaja')).toBeVisible();
-  await expect(page.getByText('3 osaamista')).toHaveCount(2);
+  const rows = page.getByTestId('work-history-summary-table').locator('tbody tr');
+
+  if (isMobile) {
+    await expect(rows.nth(0).locator('td').nth(0)).toContainText('Testi Oy');
+    await expect(rows.nth(0).locator('td').nth(0)).toContainText('1/2001');
+    await expect(rows.nth(0).locator('td').nth(1)).toHaveText('3');
+  } else {
+    await expect(rows.nth(0).locator('td').nth(0)).toHaveText('Testi Oy');
+    await expect(rows.nth(0).locator('td').nth(1)).toHaveText('1/2001');
+    await expect(rows.nth(0).locator('td').nth(2)).toBeEmpty();
+    await expect(rows.nth(0).locator('td').nth(3)).toHaveText('3');
+
+    // Second row is for osaamiset when they are uncollapsed, so we check the third row
+    await expect(rows.nth(2).locator('td').nth(0)).toHaveText('Testaaja');
+    await expect(rows.nth(2).locator('td').nth(1)).toHaveText('1/2001');
+    await expect(rows.nth(2).locator('td').nth(2)).toBeEmpty();
+    await expect(rows.nth(2).locator('td').nth(3)).toHaveText('3');
+  }
 
   const requestPromise = page.waitForRequest(
     (request) => request.url().includes('/api/profiili/tyopaikat') && request.method() === 'POST',
@@ -50,31 +75,24 @@ test('add new workhistory', async ({ page }) => {
 });
 
 test('delete workhistory item', async ({ page }) => {
-  await mockAuthenticatedUser(page);
-  await mockWorkHistory(page);
-
-  await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/tyopaikkani');
-
   // Edit the first work history item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
   await page.getByRole('button', { name: 'Poista työpaikka' }).click();
+  const confirmButton = page.locator('button.ds\\:bg-alert', { hasText: 'Poista työpaikka' }).last();
+  await expect(confirmButton).toBeVisible();
 
-  const deleteRequestPromise = page.waitForRequest(
-    (request) => request.url().includes('/api/profiili/tyopaikat') && request.method() === 'DELETE',
-  );
-  await page.getByRole('button', { name: 'Poista työpaikka' }).click();
-  const request = await deleteRequestPromise;
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (request) => request.url().includes('/api/profiili/tyopaikat') && request.method() === 'DELETE',
+    ),
+    confirmButton.click(),
+  ]);
   const expectedId = workHistory[0].id;
   expect(request.url()).toContain('/api/profiili/tyopaikat/');
   expect(request.url()).toContain(expectedId);
 });
 
 test('edit workhistory item', async ({ page }) => {
-  await mockAuthenticatedUser(page);
-  await mockWorkHistory(page);
-
-  await page.goto('/yksilo/fi/omat-sivuni/osaamiseni/tyopaikkani');
-
   // Edit the first work history item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
 

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,6 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('has title', async ({ page }) => {
-  await page.goto('/');
-  await expect(page).toHaveTitle(/Osaamispolku/);
-});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -44,12 +44,15 @@ export const workHistoryItem = {
       nimi: {
         fi: 'Testaaja',
       },
+      kuvaus: {
+        fi: 'Työpaikan kuvaus',
+      },
       alkuPvm: '2001-01-01',
       loppuPvm: '',
       osaamiset: [
-        'http://data.europa.eu/esco/skill/d33b9bd2-6dcb-4abc-b3c2-96b8983d5c97',
-        'http://data.europa.eu/esco/skill/e286eddc-75e5-4ae3-966b-ec89c1c046ba',
         'http://data.europa.eu/esco/skill/41730268-d97a-42dd-b6e0-b117d9432eb5',
+        'http://data.europa.eu/esco/skill/e286eddc-75e5-4ae3-966b-ec89c1c046ba',
+        'http://data.europa.eu/esco/skill/d33b9bd2-6dcb-4abc-b3c2-96b8983d5c97',
       ],
     },
   ],
@@ -145,12 +148,15 @@ export const freetimeActivityItem = {
   patevyydet: [
     {
       nimi: { fi: 'Uima-altaan testaus' },
+      kuvaus: {
+        fi: 'Toiminnon kuvaus',
+      },
       alkuPvm: '2001-07-01',
       loppuPvm: '2001-07-30',
       osaamiset: [
-        'http://data.europa.eu/esco/skill/eb0d83b2-3aa4-4a36-a60a-99b6746429e2',
-        'http://data.europa.eu/esco/skill/9926889a-7074-4e37-acce-1271fe6c5a6f',
         'http://data.europa.eu/esco/skill/e93acbe5-535a-4927-9e7c-3b2e06ddfee8',
+        'http://data.europa.eu/esco/skill/9926889a-7074-4e37-acce-1271fe6c5a6f',
+        'http://data.europa.eu/esco/skill/eb0d83b2-3aa4-4a36-a60a-99b6746429e2',
       ],
     },
   ],
@@ -284,11 +290,14 @@ export const educationHistoryItem = {
     {
       nimi: { fi: 'Oppilas' },
       alkuPvm: '2001-01-01',
+      kuvaus: {
+        fi: 'Koulutuksen kuvaus',
+      },
       loppuPvm: '',
       osaamiset: [
-        'http://data.europa.eu/esco/skill/edff6d20-660d-4d33-b412-9a5b664a14be',
-        'http://data.europa.eu/esco/skill/31b67516-af16-4b97-8430-a8a8e0f84190',
         'http://data.europa.eu/esco/skill/7ee872de-db39-4ae3-8e19-75d1a2cdf697',
+        'http://data.europa.eu/esco/skill/31b67516-af16-4b97-8430-a8a8e0f84190',
+        'http://data.europa.eu/esco/skill/edff6d20-660d-4d33-b412-9a5b664a14be',
       ],
     },
   ],
@@ -316,3 +325,12 @@ export const educationHistory = [
     ],
   },
 ];
+
+export const featureFlags = {
+  KOHTAANTO_KUVAUKSET: true,
+  VIRTUAALIOHJAAJA: true,
+  VIRTUAALIOHJAAJA_OSAAMISET: true,
+  TMT_INTEGRATION: true,
+  JAKOLINKKI: true,
+  MAHDOLLISUUDET_HAKU: true,
+};

--- a/e2e/mocks.ts
+++ b/e2e/mocks.ts
@@ -1,6 +1,33 @@
 import { Page } from '@playwright/test';
 import type { components } from '../src/api/schema';
-import { userProfile } from './fixtures';
+import { featureFlags, userProfile } from './fixtures';
+
+export async function mockRedundantEndpoints(page: Page) {
+  await page.route('**/manifest-fi.json', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  const emptySvg = '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>';
+
+  await page.route('**/favicon*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: emptySvg,
+    });
+  });
+  await page.route('**/apple-touch-icon.png', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: emptySvg,
+    });
+  });
+}
 
 export async function mockAuthenticatedUser(page: Page) {
   await page.route('**/api/profiili/yksilo', async (route) => {
@@ -8,6 +35,19 @@ export async function mockAuthenticatedUser(page: Page) {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(userProfile),
+    });
+  });
+}
+
+export async function mockFeatureFlags(page: Page, flags: Record<string, boolean> = {}) {
+  await page.route('**/config/features.json', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...featureFlags,
+        ...flags,
+      }),
     });
   });
 }
@@ -56,7 +96,14 @@ type ProfileWizardData = {
   nimi: components['schemas']['LokalisoituTeksti'];
 } & ProfileData;
 
-export async function mockProfileWizard(page: Page, profilePage: string, data: ProfileWizardData[]) {
+type ProfilePageName =
+  | 'tyopaikat'
+  | 'vapaa-ajan-toiminnot'
+  | 'koulutuskokonaisuudet'
+  | 'muu-osaaminen'
+  | 'kiinnostukset';
+
+export async function mockProfileWizard(page: Page, profilePage: ProfilePageName, data: ProfileWizardData[]) {
   await page.route(`**/api/profiili/${profilePage}/*`, async (route) => {
     const req = route.request();
     const method = req.method();
@@ -78,7 +125,11 @@ export async function mockProfileWizard(page: Page, profilePage: string, data: P
     }
 
     if (method === 'PUT') {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
       return;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260415-1/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-2/jod-design-system-0.0.0.tgz",
         "driver.js": "1.4.0",
         "i18next": "25.10.10",
         "i18next-http-backend": "3.0.4",
@@ -1088,8 +1088,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260415-1/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-APs4wPItvilezaIlsYdMvukhhoXmgzq6tvYk6ZEYI4Ou0R8CbOalyeD7t44kmjnUFKUaBoJf3zvpsmLTfiD70w==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-2/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-PoMDqt8IRtbt9iuUvcFkQj/myClMwXJ3bZ59p3R6CsGJ8Chcxk2T6BX2Wp5hAg9Q45e43wNDGXfeWb33OT6Hmg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260415-1/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-2/jod-design-system-0.0.0.tgz",
     "driver.js": "1.4.0",
     "i18next": "25.10.10",
     "i18next-http-backend": "3.0.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [['github'], ['html']] : 'html',
   use: {
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
     baseURL: 'http://localhost:8080',
     trace: 'on-first-retry',
     headless: !!process.env.CI,
@@ -34,10 +37,6 @@ export default defineConfig({
       use: { ...devices['Desktop Edge'], channel: 'msedge' },
     },
     {
-      name: 'Tablet iPad',
-      use: { ...devices['iPad Pro 11'] },
-    },
-    {
       name: 'Mobile Safari',
       use: { ...devices['iPhone 14'] },
     },
@@ -48,7 +47,7 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI ? 'vite preview --port 8080' : 'vite dev',
-    url: 'http://localhost:8080',
+    url: 'http://localhost:8080/yksilo/',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/components/OsaamisSuosittelija/OsaamisSuosittelija.tsx
+++ b/src/components/OsaamisSuosittelija/OsaamisSuosittelija.tsx
@@ -4,7 +4,7 @@ import type { components } from '@/api/schema';
 import { ESCO_SKILL_PREFIX, LIMITS } from '@/constants';
 import { useDebounceState } from '@/hooks/useDebounceState';
 import type { OsaaminenLahdeTyyppi } from '@/routes/types';
-import { Textarea, cx } from '@jod/design-system';
+import { Textarea, cx, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TagAreas } from './TagAreas';
@@ -70,6 +70,8 @@ export const OsaamisSuosittelija = ({
   const [resultChangeReason, setResultChangeReason] = React.useState<'fetch' | 'user' | null>(null); // To track if the change in results was caused by either user input or fetch results. Screen reader should only announce results found after fetch, not after user filtering.
   const pendingTaitosi = React.useRef<string | null>(null);
   const textareaContainerRef = React.useRef<HTMLDivElement>(null);
+  const { reduceMotion } = useMediaQueries();
+  const shouldAnimate = reduceMotion ? false : useAnimations;
 
   // Scroll textarea to top when focused
   React.useEffect(() => {
@@ -240,7 +242,7 @@ export const OsaamisSuosittelija = ({
           onChange={onChange}
           ehdotetutOsaamiset={filteredEhdotetutOsaamiset}
           isTagSpacing={isTagSpacing}
-          useAnimations={useAnimations}
+          useAnimations={shouldAnimate}
           setResultChangeReason={setResultChangeReason}
           hideSelected={hideSelected}
           tagHeadingClassName={tagHeadingClassName}

--- a/src/routes/Profile/MyGoals/addPlan/customPlan/SelectCompetencesStep.tsx
+++ b/src/routes/Profile/MyGoals/addPlan/customPlan/SelectCompetencesStep.tsx
@@ -3,7 +3,7 @@ import AddedTags from '@/components/OsaamisSuosittelija/AddedTags';
 import { useArrowKeyControls } from '@/hooks/useArrowKeyControls';
 import { getLocalizedText } from '@/utils';
 import { animateElementToTarget } from '@/utils/animations';
-import { EmptyState, Tag } from '@jod/design-system';
+import { EmptyState, Tag, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +22,7 @@ const SelectCompetencesStep = () => {
   >([]);
 
   const { control } = useFormContext<OmaSuunnitelmaForm>();
+  const { reduceMotion } = useMediaQueries();
   const {
     append,
     remove,
@@ -136,7 +137,7 @@ const SelectCompetencesStep = () => {
                     osaamiset={valitutOsaamiset.map((o) => ({ id: o.uri, nimi: o.nimi, kuvaus: o.kuvaus }))}
                     onClick={removeOsaaminenById}
                     lahdetyyppi="KOULUTUS"
-                    useAnimations
+                    useAnimations={!reduceMotion}
                   />
                 </ul>
               </div>


### PR DESCRIPTION
## Description


* Update e2e tests
  * Reflected UI changes to the tests
  * Made some tests more specific, like "table column x should have text y" instead of the text being somewhere in the table.
* Enabled e2e tests in build workflow
* Mocked some redundant API calls, like for fetching favicons etc.
* Removed example test
* Removed iPad from testable devices, because:
  * Our UI does not have a specific tablet layout
  * Prevents using `isMobile` in tests (because Playwright assumes that tablet is a mobile device but our UI goes uses desktop layout on iPad dimensions.
* Updated DS to get support for `prefer-reduced-motion`.
  * Use that setting in Playwright config
  * Disable tag animations is reduced motion is preferred

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3332
