### PR TITLE
OPHJOD-3317: Fix education import table padding

### DIFF
--- a/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
@@ -299,7 +299,7 @@ const ImportKoulutusSummaryModal = ({
               )}
             </div>
             {!isFetching && !error && (
-              <div className="max-w-modal-content">
+              <div className="max-w-modal-content box-content px-5 md:px-9">
                 <EducationImportTable rows={tableRows} />{' '}
               </div>
             )}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Fix the padding of education import modal's table.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3317
