### PR TITLE
OPHJOD-3274: Fix text color on PlanOpportunityCard

### DIFF
--- a/src/routes/Profile/MyGoals/addPlan/selectPlan/PlanOpportunityCard.tsx
+++ b/src/routes/Profile/MyGoals/addPlan/selectPlan/PlanOpportunityCard.tsx
@@ -83,7 +83,7 @@ const PlanOpportunityCard = React.memo(
 
         <Accordion
           title={getLocalizedText(otsikko)}
-          className={textColorClassName}
+          titleClassName={textColorClassName}
           initialState={false}
           fetchData={fetchOsaamiset}
           ellipsis={false}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

- Fix text color on PlanOpportunityCard
  - Content color was also same color as title, which was not wanted.

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3274
