### PR TITLE
OPHJOD-3348: Sort experience rows by latest date

### DIFF
--- a/src/components/ExperienceTable/ExperienceTable.tsx
+++ b/src/components/ExperienceTable/ExperienceTable.tsx
@@ -62,6 +62,29 @@ export const ExperienceTable = ({
   const { t } = useTranslation();
   const { sm } = useMediaQueries();
 
+  // Show ongoing rows without an end date first, then sort by latest end date and latest start date.
+  const sortRowsByLatestDate = React.useCallback((a: ExperienceTableRowData, b: ExperienceTableRowData) => {
+    if (!a.loppuPvm && b.loppuPvm) {
+      return -1;
+    }
+
+    if (a.loppuPvm && !b.loppuPvm) {
+      return 1;
+    }
+
+    const aEndDate = a.loppuPvm?.getTime() ?? 0;
+    const bEndDate = b.loppuPvm?.getTime() ?? 0;
+
+    if (aEndDate !== bEndDate) {
+      return bEndDate - aEndDate;
+    }
+
+    const aStartDate = a.alkuPvm?.getTime() ?? 0;
+    const bStartDate = b.alkuPvm?.getTime() ?? 0;
+
+    return bStartDate - aStartDate;
+  }, []);
+
   // To track Checkbox checked status with indeterminate state.
   const [rowsCheckboxState, setRowsCheckboxState] = React.useState<
     Map<
@@ -162,7 +185,17 @@ export const ExperienceTable = ({
   };
 
   const uncategorizedRows = rows.filter((row) => !row.subrows);
-  const categorizedRows = rows.filter((row) => row.subrows);
+  const categorizedRows = React.useMemo(
+    () =>
+      rows
+        .filter((row) => row.subrows)
+        .map((row) => ({
+          ...row,
+          subrows: [...(row.subrows ?? [])].sort(sortRowsByLatestDate),
+        }))
+        .sort(sortRowsByLatestDate),
+    [rows, sortRowsByLatestDate],
+  );
 
   const thPadding = insideModal ? 'md:pl-6' : 'sm:pl-6';
 


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
Sort experience rows by latest date
 
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
<img width="742" height="703" alt="Screenshot 2026-04-21 at 8 17 14" src="https://github.com/user-attachments/assets/cc5fcb81-4f8a-4add-8d5a-697fa2d47f87" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3348
