### PR TITLE
OPHJOD-3350: Fix focus outline style in Root

### DIFF
--- a/src/components/IconHeading/index.tsx
+++ b/src/components/IconHeading/index.tsx
@@ -25,7 +25,7 @@ export const IconHeading = ({
       )}
       <h1
         data-testid={testId}
-        className={`text-hero-mobile sm:text-hero hyphens-auto text-pretty break-words focus:outline-0 ${textClassName}`}
+        className={`text-hero-mobile sm:text-hero hyphens-auto text-pretty wrap-break-word focus:outline-0 ${textClassName}`}
       >
         {title}
       </h1>

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -115,6 +115,7 @@ const Home = () => {
         <HeroCard
           title={t('home.hero-title')}
           titleLevel={1}
+          titleClassName="text-hero-mobile sm:text-hero focus:outline-0"
           content={t('home.hero-content')}
           backgroundColor="var(--ds-color-secondary-1-dark-2)"
         />


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Remove redundant focus handling in Root
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3350
