### PR TITLE
OPHJOD-3380: Always show the welcome path modal if not done

### DIFF
--- a/e2e/mocks.ts
+++ b/e2e/mocks.ts
@@ -37,6 +37,23 @@ export async function mockAuthenticatedUser(page: Page) {
       body: JSON.stringify(userProfile),
     });
   });
+  await page.route('**/api/profiili/yksilo/tiedot-ja-luvat', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        allowKotikunta: true,
+        allowSyntymavuosi: true,
+        allowSukupuoli: true,
+        kotikunta: 'kunta_123',
+        kotikuntaNimi: 'Testikunta',
+        syntymavuosi: 1990,
+        sukupuoli: 'MIES',
+        sukupuoliNimi: 'Mies',
+        tervetuloapolku: true,
+      }),
+    });
+  });
 }
 
 export async function mockFeatureFlags(page: Page, flags: Record<string, boolean> = {}) {

--- a/src/hooks/useYksiloData/index.ts
+++ b/src/hooks/useYksiloData/index.ts
@@ -2,6 +2,7 @@ import { client } from '@/api/client';
 import type { components } from '@/api/schema';
 import type { LanguageValue } from '@/i18n/config';
 import type { GenderValue } from '@/routes/Profile/utils';
+import { useIsLoggedIn } from '@/stores/useSessionManagerStore';
 import { getCodesetValue } from '@/utils/codes/codes';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,6 +26,7 @@ export const useYksiloData = () => {
   const [kotikuntaNimi, setKotikuntaNimi] = React.useState<string>('');
   const [isLoading, setIsLoading] = React.useState(true);
   const language = i18n.language as LanguageValue;
+  const isLoggedIn = useIsLoggedIn();
 
   const sukupuoliText = (sukupuoli: GenderValue | undefined) => {
     switch (sukupuoli) {
@@ -52,8 +54,10 @@ export const useYksiloData = () => {
   }, [language]);
 
   React.useEffect(() => {
-    fetchApiData();
-  }, [fetchApiData]);
+    if (isLoggedIn) {
+      fetchApiData();
+    }
+  }, [fetchApiData, isLoggedIn]);
 
   return {
     data: {

--- a/src/routes/Profile/ProfileFront/ProfileFront.tsx
+++ b/src/routes/Profile/ProfileFront/ProfileFront.tsx
@@ -1,13 +1,11 @@
 import { ExternalLink, MainLayout } from '@/components';
 import { IconHeading } from '@/components/IconHeading';
-import { useYksiloData } from '@/hooks/useYksiloData';
 import { useSessionManagerStore } from '@/stores/useSessionManagerStore';
 import { useMediaQueries } from '@jod/design-system';
 import { JodUser } from '@jod/design-system/icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { ProfileNavigationList } from '../components';
 import { ToolCard } from '../components/ToolCard';
-import WelcomePathModal from '../WelcomePathModal/WelcomePathModal';
 
 const ListItem = ({ label }: { label: string }) => <li className="list-disc ml-6 ">{label}</li>;
 
@@ -18,7 +16,6 @@ const ProfileFront = () => {
   } = useTranslation();
   const { lg } = useMediaQueries();
   const firstName = useSessionManagerStore((s) => s.user?.etunimi);
-  const { data, isLoading } = useYksiloData();
 
   return (
     <MainLayout
@@ -41,8 +38,6 @@ const ProfileFront = () => {
           title={t('welcome', { name: firstName ?? 'Nimetön' })}
           testId="profile-front-title"
         />
-
-        {!isLoading && !data.tervetuloapolku && <WelcomePathModal yksiloData={data} />}
 
         <div className="mb-8 text-body-md flex flex-col gap-6 font-arial">
           <p className="text-body-lg-mobile sm:text-body-lg font-poppins mb-3">

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -3,6 +3,7 @@ import { NavMenu } from '@/components/NavMenu/NavMenu';
 import { SearchBar } from '@/components/SearchBar/SearchBar';
 import { Toaster } from '@/components/Toaster/Toaster';
 import { useLocalizedRoutes } from '@/hooks/useLocalizedRoutes';
+import { useYksiloData } from '@/hooks/useYksiloData';
 import { langLabels, supportedLanguageCodes, type LangCode } from '@/i18n/config';
 import { useIsLoggedIn, useSessionManagerStore } from '@/stores/useSessionManagerStore';
 import { useToolStore } from '@/stores/useToolStore';
@@ -29,6 +30,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, NavLink, Outlet, ScrollRestoration, useLoaderData, useLocation, useMatch } from 'react-router';
 import { LogoutFormContext } from '.';
+import WelcomePathModal from '../Profile/WelcomePathModal/WelcomePathModal';
 import { useSessionManagerNotifications } from './useSessionManagerNotifications';
 
 const LanguageButtonWrapper = ({ responsive }: { responsive?: boolean }) => {
@@ -135,8 +137,14 @@ const Root = () => {
       href: `/${language}/${t('common:slugs.privacy-and-cookies')}`,
       label: t('common:footer.more-info-links.privacy-and-cookies'),
     },
-    { href: `/${language}/${t('common:slugs.data-sources')}`, label: t('common:footer.more-info-links.data-sources') },
-    { href: `/${language}/${t('common:slugs.ai-usage')}`, label: t('common:footer.more-info-links.ai-usage') },
+    {
+      href: `/${language}/${t('common:slugs.data-sources')}`,
+      label: t('common:footer.more-info-links.data-sources'),
+    },
+    {
+      href: `/${language}/${t('common:slugs.ai-usage')}`,
+      label: t('common:footer.more-info-links.ai-usage'),
+    },
     {
       href: `/${language}/${t('common:slugs.accessibility')}`,
       label: t('common:footer.more-info-links.accessibility'),
@@ -186,6 +194,8 @@ const Root = () => {
   }, [addTemporaryNote, t, language]);
 
   const { open: openCookieConsent } = useCookieConsent();
+
+  const { data: yksiloData, isLoading } = useYksiloData();
 
   return (
     <div className="flex flex-col min-h-screen bg-bg-gray text-primary-gray" data-testid="app-root">
@@ -241,6 +251,8 @@ const Root = () => {
           testId="navigation-bar"
         />
       </header>
+
+      {!isLoading && !yksiloData.tervetuloapolku && isLoggedIn && <WelcomePathModal yksiloData={yksiloData} />}
 
       <LogoutFormContext.Provider value={logoutForm}>
         <NavMenu


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Always show the welcome path modal if not done
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3380
