### PR TITLE
OPHJOD-2498: Add inactive tag to opportunities

### DIFF
--- a/src/api/mahdollisuusService.ts
+++ b/src/api/mahdollisuusService.ts
@@ -50,6 +50,7 @@ export const getTypedTyoMahdollisuusDetails = async (ids: string[]): Promise<Typ
     (await getTyoMahdollisuusDetails(ids)).map((mahdollisuus) => ({
       ...mahdollisuus,
       mahdollisuusTyyppi: 'TYOMAHDOLLISUUS',
+      isActiveOpportunity: mahdollisuus.aktiivinen,
     })),
   );
 
@@ -95,5 +96,6 @@ export const getTypedKoulutusMahdollisuusDetails = async (ids: string[]): Promis
     (await getKoulutusMahdollisuusDetails(ids)).map((mahdollisuus) => ({
       ...mahdollisuus,
       mahdollisuusTyyppi: 'KOULUTUSMAHDOLLISUUS',
+      isActiveOpportunity: mahdollisuus.aktiivinen,
     })),
   );

--- a/src/components/OpportunityCard/OpportunityCard.tsx
+++ b/src/components/OpportunityCard/OpportunityCard.tsx
@@ -14,6 +14,7 @@ import { useIsSessionExpired } from '@/stores/useSessionManagerStore';
 
 import { OpportunityType } from '../OpportunityType/OpportunityType';
 import { TitleIcon } from '../TitleIcon/TitleIcon';
+import { InActiveTag } from './components/InActiveTag';
 import { EducationOpportunityCard } from './EducationOpportunityCard';
 import { JobOpportunityCard } from './JobOpportunityCard';
 
@@ -70,6 +71,7 @@ interface BaseProps {
   description: string;
   matchValue?: number;
   matchLabel?: string;
+  isActiveOpportunity?: boolean;
   mahdollisuusTyyppi: MahdollisuusTyyppi;
   mahdollisuusAlityyppi: MahdollisuusAlityyppi;
   headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -97,6 +99,7 @@ interface ActionsSectionProps {
   name: string;
   matchValue?: number;
   matchLabel?: string;
+  isActiveOpportunity?: boolean;
 }
 
 const ActionsSection = ({
@@ -110,6 +113,7 @@ const ActionsSection = ({
   isLoggedIn,
   matchValue,
   matchLabel,
+  isActiveOpportunity,
 }: ActionsSectionProps) => {
   const hasMatchInfo = typeof matchValue === 'number' && matchLabel;
   const nothingToShow = hideFavorite && !menuId && !menuContent && !actionButtonContent && !hasMatchInfo;
@@ -118,6 +122,7 @@ const ActionsSection = ({
     <></>
   ) : (
     <div className="flex flex-row items-center justify-between sm:mb-3">
+      {!isActiveOpportunity && <InActiveTag name={name} />}
       {hasMatchInfo ? (
         <div
           className={'flex flex-col flex-nowrap items-center gap-x-2 select-none sm:flex-row'}
@@ -162,6 +167,7 @@ export const OpportunityCardWrapper = ({
   name,
   mahdollisuusTyyppi,
   mahdollisuusAlityyppi,
+  isActiveOpportunity,
   toggleFavorite,
   isFavorite,
   isLoggedIn,
@@ -231,6 +237,7 @@ export const OpportunityCardWrapper = ({
         actionButtonContent={actionButtonContent}
         matchValue={matchValue}
         matchLabel={matchLabel}
+        isActiveOpportunity={isActiveOpportunity}
       />
       {collapsible ? (
         <Accordion

--- a/src/components/OpportunityCard/components/InActiveTag.tsx
+++ b/src/components/OpportunityCard/components/InActiveTag.tsx
@@ -1,0 +1,47 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+import { JodError } from '@jod/design-system/icons';
+
+import { AnchorLink } from '@/components/AnchorLink/AnchorLink';
+import { TooltipWrapper } from '@/components/Tooltip/TooltipWrapper';
+
+interface InActiveTagProps {
+  name?: string;
+}
+
+export const InActiveTag = ({ name }: InActiveTagProps) => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
+
+  return (
+    <TooltipWrapper
+      tooltipPlacement="top"
+      triggerClassName="flex items-center gap-3 rounded-2xl px-4 bg-warning self-start"
+      tooltipContent={
+        <div className="max-w-[290px] text-body-xs leading-5">
+          <Trans
+            i18nKey="profile.favorites.inActiveTagTooltip"
+            components={{
+              CustomLink: (
+                <AnchorLink
+                  href={`/yksilo/${language}/${t('slugs.search')}?q=${name}`}
+                  className="inline-flex underline"
+                  target="_blank"
+                />
+              ),
+            }}
+          />
+        </div>
+      }
+    >
+      <div className="flex items-center gap-3">
+        <JodError size={16} className="text-primary-gray" />
+        <span className="rounded-2xl font-semibold py-2 text-[0.8rem] text-nowrap">
+          {t('profile.favorites.inActiveTag')}
+        </span>
+      </div>
+    </TooltipWrapper>
+  );
+};

--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -666,6 +666,8 @@
         "title": "Set goals and make plans"
       },
       "job-and-education-opportunities": "Education and career opportunities",
+      "inActiveTag": "Please note",
+      "inActiveTagTooltip": "The content suggested by the service has been updated, which means that the description of the saved job opportunity or occupation may have changed. You can still use the information saved as a favorite to create a goal. <CustomLink>Perform a search using the favorite’s title</CustomLink> if you want to save the updated information to your favorites",
       "link-to-opportunities": "Find opportunities",
       "show-filters": "Show filters",
       "title": "Favourites",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -663,6 +663,8 @@
         "link-text": "Luo tavoite",
         "title": "Aseta tavoitteita ja tee suunnitelmia"
       },
+      "inActiveTag": "Huomioitavaa",
+      "inActiveTagTooltip": "Palvelun ehdottama sisältö on päivitetty, minkä seurauksena tallentamasi työmahdollisuuden tai ammatin kuvaus on voinut muuttua. Voit silti käyttää suosikiksi tallennettua tietoa tavoitteen muodostamiseen. <CustomLink>Suorita haku suosikin otsikolla</CustomLink>, mikäli haluat tallentaa ajatasaisen tiedon suosikkeihin",
       "job-and-education-opportunities": "Koulutus- ja työmahdollisuudet",
       "link-to-opportunities": "Löydä mahdollisuuksia",
       "show-filters": "Näytä suodattimet",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -664,6 +664,8 @@
         "link-text": "Skapa mål",
         "title": "Sätt upp mål och gör planer"
       },
+      "inActiveTag": "Observera",
+      "inActiveTagTooltip": "Det innehåll som tjänsten föreslår har uppdaterats, vilket innebär att beskrivningen av den jobbmöjlighet eller det yrke som du har sparat kan ha ändrats. Du kan fortfarande använda den sparade favoritinformationen för att skapa ett mål. <CustomLink>Gör en sökning med favoritens titel</CustomLink> om du vill spara uppdaterad information bland dina favoriter.",
       "job-and-education-opportunities": "Utbildnings- och karriärmöjligheter",
       "link-to-opportunities": "Hitta möjligheter",
       "show-filters": "Visa filter",

--- a/src/routes/Cv/Cv.tsx
+++ b/src/routes/Cv/Cv.tsx
@@ -159,6 +159,7 @@ const Cv = () => {
       mahdollisuusAlityyppi={getMahdollisuusAlityyppi(mahdollisuus)}
       kesto={mahdollisuus.kesto}
       yleisinKoulutusala={mahdollisuus.yleisinKoulutusala}
+      isActiveOpportunity={mahdollisuus.aktiivinen}
     />
   );
 

--- a/src/routes/Profile/Favorites/Favorites.tsx
+++ b/src/routes/Profile/Favorites/Favorites.tsx
@@ -281,6 +281,7 @@ const Favorites = () => {
               name={getLocalizedText(mahdollisuus.otsikko)}
               toggleFavorite={guardedAction(deleteSuosikki, id)}
               mahdollisuusTyyppi={mahdollisuusTyyppi}
+              isActiveOpportunity={mahdollisuus.aktiivinen}
               mahdollisuusAlityyppi={getMahdollisuusAlityyppi(mahdollisuus)}
               kesto={mahdollisuus.kesto}
               yleisinKoulutusala={mahdollisuus.yleisinKoulutusala}

--- a/src/routes/Profile/MyGoals/MyGoalsSection.tsx
+++ b/src/routes/Profile/MyGoals/MyGoalsSection.tsx
@@ -114,6 +114,7 @@ const MyGoalsSection = ({ tavoitteet }: MyGoalsSectionProps) => {
                           yleisinKoulutusala={details.yleisinKoulutusala}
                           headingLevel="h3"
                           hideFavorite
+                          isActiveOpportunity={details.aktiivinen}
                         />
                         <PlanList
                           goal={tavoite}

--- a/src/routes/Profile/MyGoals/addGoal/GoalModal.tsx
+++ b/src/routes/Profile/MyGoals/addGoal/GoalModal.tsx
@@ -263,6 +263,7 @@ export const GoalModal = ({ mode, tavoite, ...rest }: GoalModalProps) => {
                         initiallyCollapsed
                         collapsible
                         hideFavorite
+                        isActiveOpportunity={mahdollisuus.aktiivinen}
                         actionButtonContent={
                           isSelected ? (
                             <div className="flex items-center gap-4 not-sm:justify-between">


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add inactive tag to favorites
<img width="721" height="268" alt="Screenshot 2026-05-12 at 12 08 50" src="https://github.com/user-attachments/assets/b905354c-f9db-4517-871a-b6781724d59a" />

<img width="624" height="284" alt="Screenshot 2026-05-12 at 12 09 11" src="https://github.com/user-attachments/assets/7c268ca5-c4d1-458d-ba05-6acdbd07ef24" />
<img width="657" height="484" alt="Screenshot 2026-05-12 at 12 14 31" src="https://github.com/user-attachments/assets/a8450d7f-f3e1-47e7-8f36-73d89226825e" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2498
