### PR TITLE
OPHJOD-2498: Fix inactive tag showing in tool

### DIFF
--- a/src/components/OpportunityCard/OpportunityCard.tsx
+++ b/src/components/OpportunityCard/OpportunityCard.tsx
@@ -122,7 +122,7 @@ const ActionsSection = ({
     <></>
   ) : (
     <div className="flex flex-row items-center justify-between sm:mb-3">
-      {!isActiveOpportunity && <InActiveTag name={name} />}
+      {isActiveOpportunity === false && <InActiveTag name={name} />}
       {hasMatchInfo ? (
         <div
           className={'flex flex-col flex-nowrap items-center gap-x-2 select-none sm:flex-row'}

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -290,7 +290,9 @@ const YourInfo = () => {
             </ToolAccordion>
 
             <ToolAccordion
-              title={t('tool.competency-profile.title', { count: profileCompetencesCount })}
+              title={t('tool.competency-profile.title', {
+                count: profileCompetencesCount,
+              })}
               testId="tool-profile-accordion"
             >
               <ProfileImportExport />
@@ -528,7 +530,7 @@ const Tool = () => {
                   onKeyDown={(event) => onKeyDown(event, index)}
                   id={`tab-${tab.text}`}
                   aria-selected={tab.active}
-                  className={cx('flex grow cursor-pointer items-center justify-center rounded-t bg-white py-4', {
+                  className={cx('flex grow cursor-pointer items-center justify-center rounded-t-md bg-white py-4', {
                     'text-accent': tab.active,
                     'bg-bg-gray-2': !tab.active,
                   })}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
 Fix inactive tag showing in tool
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2498
