### PR TITLE
OPHJOD-3389: Update CV import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260511-1/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260518-1/jod-design-system-0.0.0.tgz",
         "driver.js": "1.4.0",
         "i18next": "25.10.10",
         "i18next-http-backend": "3.0.4",
@@ -921,8 +921,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260511-1/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-6hVLnh6AlOEUVcnmd4gDBjbKybBFaEHNeH68poXoZ9gyNsftm5L2+5ePCrpM+o+XBhffMRFasYcWNC/MlvIZ4g==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260518-1/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-zPgzcYknmrxKtnWxiMbZEuZUXeBWI5IveblVscH82AsE8fJfJzGc62RYxyONtU7lwCKTDahtpt5ylEFVqx7aPQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260511-1/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260518-1/jod-design-system-0.0.0.tgz",
     "driver.js": "1.4.0",
     "i18next": "25.10.10",
     "i18next-http-backend": "3.0.4",

--- a/src/components/DataImportTable/DataImportTable.tsx
+++ b/src/components/DataImportTable/DataImportTable.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Checkbox, useMediaQueries } from '@jod/design-system';
 
-import { ExperienceTableRowData } from '@/components/ExperienceTable/ExperienceTableRow';
+import { ExperienceTableRowData, FreeFormTextRow } from '@/components/ExperienceTable/ExperienceTableRow';
 import { formatDate, getLocalizedText } from '@/utils';
 
 export interface DataImportTableProps {
@@ -137,43 +137,46 @@ export const DataImportTable = ({ rows, toggleAllSelectionText }: DataImportTabl
               )}
             </tr>
             {(row.subrows ?? []).map((subrow, i) => (
-              <tr key={subrow.key} className={i % 2 === 0 ? '' : 'bg-bg-gray-2'}>
-                <td className="py-3 pl-6 text-heading-5-mobile sm:pl-9 sm:text-heading-5" colSpan={sm ? 3 : 1}>
-                  <div className={`flex ${sm ? 'flex-row' : 'flex-col'}`}>
-                    <div className="flex items-center gap-3 sm:gap-5">
-                      <Checkbox
-                        name={`checkbox-${subrow.key}`}
-                        value={subrow.key}
-                        checked={subrow?.checked ?? false}
-                        onChange={(e) => {
-                          subrow.checked = e.target.checked;
-                          rerender();
-                        }}
-                        ariaLabel={`${t('choose')} ${subrow.nimi[language]}`}
-                        testId={`experience-row-checkbox-${subrow.key}`}
-                      />
-                      {getLocalizedText(subrow.nimi)}
-                    </div>
-                    {!sm && (
-                      <div className="ml-6 flex gap-2 sm:ml-7">
-                        <span>{subrow.alkuPvm ? formatDate(subrow.alkuPvm) : ''}</span>
-                        <span>-</span>
-                        <span>{subrow.loppuPvm ? formatDate(subrow.loppuPvm) : ''}</span>
+              <>
+                <tr key={subrow.key} className={i % 2 === 0 ? '' : 'bg-bg-gray-2'}>
+                  <td className="py-3 pl-6 text-heading-5-mobile sm:pl-9 sm:text-heading-5" colSpan={sm ? 3 : 1}>
+                    <div className={`flex ${sm ? 'flex-row' : 'flex-col'}`}>
+                      <div className="flex items-center gap-3 sm:gap-5">
+                        <Checkbox
+                          name={`checkbox-${subrow.key}`}
+                          value={subrow.key}
+                          checked={subrow?.checked ?? false}
+                          onChange={(e) => {
+                            subrow.checked = e.target.checked;
+                            rerender();
+                          }}
+                          ariaLabel={`${t('choose')} ${subrow.nimi[language]}`}
+                          testId={`experience-row-checkbox-${subrow.key}`}
+                        />
+                        {getLocalizedText(subrow.nimi)}
                       </div>
-                    )}
-                  </div>
-                </td>
-                {sm && (
-                  <>
-                    <td className="py-3 text-heading-5-mobile sm:px-6 sm:text-heading-5">
-                      {subrow.alkuPvm ? formatDate(subrow.alkuPvm) : ''}
-                    </td>
-                    <td className="py-3 text-heading-5-mobile sm:pr-2 sm:text-heading-5">
-                      {subrow.loppuPvm ? formatDate(subrow.loppuPvm) : ''}
-                    </td>
-                  </>
-                )}
-              </tr>
+                      {!sm && (
+                        <div className="ml-6 flex gap-2 sm:ml-7">
+                          <span>{subrow.alkuPvm ? formatDate(subrow.alkuPvm) : ''}</span>
+                          <span>-</span>
+                          <span>{subrow.loppuPvm ? formatDate(subrow.loppuPvm) : ''}</span>
+                        </div>
+                      )}
+                    </div>
+                  </td>
+                  {sm && (
+                    <>
+                      <td className="py-3 text-heading-5-mobile sm:px-6 sm:text-heading-5">
+                        {subrow.alkuPvm ? formatDate(subrow.alkuPvm) : ''}
+                      </td>
+                      <td className="py-3 text-heading-5-mobile sm:pr-2 sm:text-heading-5">
+                        {subrow.loppuPvm ? formatDate(subrow.loppuPvm) : ''}
+                      </td>
+                    </>
+                  )}
+                </tr>
+                {subrow.kuvaus && <FreeFormTextRow row={subrow} visibleState={true} />}
+              </>
             ))}
             <tr>
               <td colSpan={3} className="pb-6" />

--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -84,7 +84,7 @@ const DateRange = ({ alkuPvm, loppuPvm, className = '' }: { alkuPvm?: Date; lopp
   </div>
 );
 
-const FreeFormTextRow = ({
+export const FreeFormTextRow = ({
   row,
   visibleState,
   className,

--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -535,6 +535,7 @@
           "no-data": "No education data identified",
           "title": "Education"
         },
+        "importing": "Importing data",
         "title": "Select information to import",
         "work": {
           "loading": "Loading work history",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -533,6 +533,7 @@
           "no-data": "Koulutustietoja ei tunnistettu",
           "title": "Koulutukset"
         },
+        "importing": "Tuodaan tietoja",
         "title": "Tuotavien tietojen valinta",
         "work": {
           "loading": "Kerätään työhistoriatietoja",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -534,6 +534,7 @@
           "no-data": "Ingen utbildningsdata identifierades",
           "title": "Utbildning"
         },
+        "importing": "Importerar data",
         "title": "Välj information att importera",
         "work": {
           "loading": "Hämtar arbetslivserfarenhet",

--- a/src/routes/Profile/Preferences/CvImport/CvImportWizard.tsx
+++ b/src/routes/Profile/Preferences/CvImport/CvImportWizard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Modal, useMediaQueries, useNoteStack } from '@jod/design-system';
+import { Button, Modal, useMediaQueries, useNoteStack, WizardProgress } from '@jod/design-system';
 import { JodArrowLeft, JodArrowRight, JodCheckmark } from '@jod/design-system/icons';
 
 import { ModalHeader } from '@/components/ModalHeader';
@@ -220,6 +220,20 @@ const CvImportWizard = ({ onClose, ...rest }: ModalComponentProps) => {
     return <></>;
   }, [isAttachmentStep, isSummaryStep, selectedFile, fileError, fileInputRef, convertedData, isLoading, state.error]);
 
+  const progress = React.useMemo(
+    () => (
+      <WizardProgress
+        labelText={t('wizard.label')}
+        stepText={t('wizard.step')}
+        completedText={t('wizard.completed')}
+        currentText={t('wizard.current')}
+        steps={steps}
+        currentStep={step}
+      />
+    ),
+    [t, steps, step],
+  );
+
   return (
     <Modal
       name={t('preferences.cv-import.title')}
@@ -230,6 +244,7 @@ const CvImportWizard = ({ onClose, ...rest }: ModalComponentProps) => {
       content={<div id={modalId}>{StepComponent}</div>}
       footer={footer}
       className="h-[90vh]! sm:h-full!"
+      progress={progress}
     />
   );
 };

--- a/src/routes/Profile/Preferences/CvImport/SummaryStep.tsx
+++ b/src/routes/Profile/Preferences/CvImport/SummaryStep.tsx
@@ -8,35 +8,19 @@ import { DataImportTable } from '@/components/DataImportTable/DataImportTable';
 import type { CvImportConvertedData } from './utils';
 
 interface SectionProps {
-  isLoading: boolean;
   hasData: boolean;
   titleText: string;
-  loadingText: string;
   noDataText: string;
   toggleAllSelectionText: string;
   rows?: ExperienceTableRowData[];
 }
 
-const Section = ({
-  isLoading,
-  hasData,
-  titleText: titleKey,
-  loadingText,
-  noDataText,
-  toggleAllSelectionText,
-  rows,
-}: SectionProps) => {
+const Section = ({ hasData, titleText: titleKey, noDataText, toggleAllSelectionText, rows }: SectionProps) => {
   return (
     <div>
       <h2 className="mb-6 text-heading-2-mobile sm:text-heading-2">{titleKey}</h2>
-      {isLoading && (
-        <div className="flex flex-row gap-5">
-          <Spinner size={24} color="accent" />
-          <p className="text-body-md">{loadingText}</p>
-        </div>
-      )}
-      {!isLoading && hasData && rows && <DataImportTable rows={rows} toggleAllSelectionText={toggleAllSelectionText} />}
-      {!isLoading && !hasData && <EmptyState text={noDataText} />}
+      {hasData && rows && <DataImportTable rows={rows} toggleAllSelectionText={toggleAllSelectionText} />}
+      {!hasData && <EmptyState text={noDataText} />}
     </div>
   );
 };
@@ -54,33 +38,44 @@ const SummaryStep = ({ isLoading, convertedData }: SummaryStepProps) => {
       <p>
         <Trans i18nKey="preferences.cv-import.summary.description" />
       </p>
-      <Section
-        isLoading={isLoading}
-        hasData={Boolean(convertedData?.education.length)}
-        titleText={t('preferences.cv-import.summary.education.title')}
-        loadingText={t('preferences.cv-import.summary.education.loading')}
-        noDataText={t('preferences.cv-import.summary.education.no-data')}
-        toggleAllSelectionText={t('education-history.education-provider-or-education')}
-        rows={convertedData?.education}
-      />
-      <Section
-        isLoading={isLoading}
-        hasData={Boolean(convertedData?.work.length)}
-        titleText={t('preferences.cv-import.summary.work.title')}
-        loadingText={t('preferences.cv-import.summary.work.loading')}
-        noDataText={t('preferences.cv-import.summary.work.no-data')}
-        toggleAllSelectionText={t('work-history.workplace-or-job-description')}
-        rows={convertedData?.work}
-      />
-      <Section
-        isLoading={isLoading}
-        hasData={Boolean(convertedData?.activities.length)}
-        titleText={t('preferences.cv-import.summary.activities.title')}
-        loadingText={t('preferences.cv-import.summary.activities.loading')}
-        noDataText={t('preferences.cv-import.summary.activities.no-data')}
-        toggleAllSelectionText={t('free-time-activities.theme-or-activity')}
-        rows={convertedData?.activities}
-      />
+      {isLoading && (
+        <div>
+          <div className="mb-5 flex flex-row gap-5">
+            <h2 className="text-heading-2-mobile sm:text-heading-2">{t('preferences.cv-import.summary.importing')} </h2>
+            <Spinner size={24} color="accent" />
+          </div>
+          <ul className="ml-6 list-disc">
+            <li>{t('preferences.cv-import.summary.education.loading')}</li>
+            <li>{t('preferences.cv-import.summary.work.loading')}</li>
+            <li>{t('preferences.cv-import.summary.activities.loading')}</li>
+          </ul>
+        </div>
+      )}
+      {!isLoading && (
+        <>
+          <Section
+            hasData={Boolean(convertedData?.education.length)}
+            titleText={t('preferences.cv-import.summary.education.title')}
+            noDataText={t('preferences.cv-import.summary.education.no-data')}
+            toggleAllSelectionText={t('education-history.education-provider-or-education')}
+            rows={convertedData?.education}
+          />
+          <Section
+            hasData={Boolean(convertedData?.work.length)}
+            titleText={t('preferences.cv-import.summary.work.title')}
+            noDataText={t('preferences.cv-import.summary.work.no-data')}
+            toggleAllSelectionText={t('work-history.workplace-or-job-description')}
+            rows={convertedData?.work}
+          />
+          <Section
+            hasData={Boolean(convertedData?.activities.length)}
+            titleText={t('preferences.cv-import.summary.activities.title')}
+            noDataText={t('preferences.cv-import.summary.activities.no-data')}
+            toggleAllSelectionText={t('free-time-activities.theme-or-activity')}
+            rows={convertedData?.activities}
+          />
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update CV import
  - Add `WizardProgress` component to modal
  - Show description/free form text if available
  - Show only one spinner when loading
- Update `@jod/design-system` (Opetushallitus/jod-design-system/pull/575)

## Screenshots

<img width="300" alt="SCR-20260518-lfqx-2" src="https://github.com/user-attachments/assets/a19fbf2e-8438-4192-9a15-6fd72deed350" />

<img width="300"  alt="SCR-20260518-lfns-2" src="https://github.com/user-attachments/assets/af69d501-1c29-4db3-9697-365c8c7cb622" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3389
