### PR TITLE
OPHJOD-2183: Change feedback toast to modal

### DIFF
--- a/src/components/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/FeedbackModal/FeedbackModal.tsx
@@ -5,10 +5,20 @@ import toast from 'react-hot-toast/headless';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import { Button, Checkbox, InputField, Modal, RadioButton, RadioButtonGroup, Textarea } from '@jod/design-system';
+import {
+  Button,
+  Checkbox,
+  InputField,
+  Modal,
+  RadioButton,
+  RadioButtonGroup,
+  Textarea,
+  useMediaQueries,
+} from '@jod/design-system';
 import { JodOpenInNew } from '@jod/design-system/icons';
 
 import { formErrorMessage } from '@/constants';
+import { useModal } from '@/hooks/useModal/useModal';
 
 const DETAILS_MAX_LENGTH = 2048;
 const MESSAGE_MAX_LENGTH = 5000;
@@ -48,6 +58,28 @@ const Feedback = z
 
 type Feedback = z.infer<typeof Feedback>;
 
+const FeedbackSuccessFooter = ({
+  hideDialog,
+  closeActiveModal,
+  label,
+  size,
+}: {
+  hideDialog: () => void;
+  closeActiveModal: () => void;
+  label: string;
+  size: 'lg' | 'sm';
+}) => (
+  <Button
+    label={label}
+    size={size}
+    variant="accent"
+    onClick={() => {
+      hideDialog();
+      closeActiveModal();
+    }}
+  />
+);
+
 export interface FeedbackModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -59,6 +91,8 @@ export interface FeedbackModalProps {
 export const FeedbackModal = ({ isOpen, onClose, section, area, language }: FeedbackModalProps) => {
   const formId = React.useId();
   const { t } = useTranslation();
+  const { showDialog, closeActiveModal } = useModal();
+  const { sm } = useMediaQueries();
 
   const { control, register, watch, reset } = useForm({
     mode: 'onChange',
@@ -74,6 +108,18 @@ export const FeedbackModal = ({ isOpen, onClose, section, area, language }: Feed
   const { isValid, errors } = useFormState({ control });
   const wantsContact = watch('wantsContact');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const successFooter = React.useCallback(
+    (hideDialog: () => void) => (
+      <FeedbackSuccessFooter
+        hideDialog={hideDialog}
+        closeActiveModal={closeActiveModal}
+        label={t('common:feedback.close')}
+        size={sm ? 'lg' : 'sm'}
+      />
+    ),
+    [closeActiveModal, t, sm],
+  );
 
   React.useEffect(() => {
     reset();
@@ -111,9 +157,11 @@ export const FeedbackModal = ({ isOpen, onClose, section, area, language }: Feed
       reset();
       onClose();
 
-      // Wait a moment before showing success message
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      toast.success(t('common:feedback.success'));
+      showDialog({
+        title: t('common:feedback.success-title'),
+        description: t('common:feedback.success-description'),
+        footer: successFooter,
+      });
     } catch {
       setIsSubmitting(false);
       toast.error(t('common:feedback.error'));

--- a/src/components/RateContent/RateContent.tsx
+++ b/src/components/RateContent/RateContent.tsx
@@ -3,13 +3,37 @@ import toast from 'react-hot-toast/headless';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
-import { RateContentCard } from '@jod/design-system';
+import { Button, RateContentCard, useMediaQueries } from '@jod/design-system';
+
+import { useModal } from '@/hooks/useModal/useModal';
 
 interface RateContentProps {
   variant: 'kohtaanto' | 'tyomahdollisuus' | 'ammatti' | 'koulutusmahdollisuus' | 'tutkinto';
   area: 'Kohtaanto työkalu' | 'Työmahdollisuus' | 'Koulutusmahdollisuus';
   size?: React.ComponentProps<typeof RateContentCard>['size'];
 }
+
+const RateContentSuccessFooter = ({
+  hideDialog,
+  closeActiveModal,
+  label,
+  size,
+}: {
+  hideDialog: () => void;
+  closeActiveModal: () => void;
+  label: string;
+  size: 'lg' | 'sm';
+}) => (
+  <Button
+    label={label}
+    size={size}
+    variant="accent"
+    onClick={() => {
+      hideDialog();
+      closeActiveModal();
+    }}
+  />
+);
 
 export const RateContent = ({ variant, area, size }: RateContentProps) => {
   const {
@@ -54,6 +78,21 @@ export const RateContent = ({ variant, area, size }: RateContentProps) => {
   const content = React.useMemo(() => {
     return variant === 'ammatti' ? t('rate-ai-content.ammatti.body') : t('rate-ai-content.mahdollisuus.body');
   }, [variant, t]);
+
+  const { showDialog, closeActiveModal } = useModal();
+  const { sm } = useMediaQueries();
+
+  const successFooter = React.useCallback(
+    (hideDialog: () => void) => (
+      <RateContentSuccessFooter
+        hideDialog={hideDialog}
+        closeActiveModal={closeActiveModal}
+        label={t('close')}
+        size={sm ? 'lg' : 'sm'}
+      />
+    ),
+    [closeActiveModal, t, sm],
+  );
 
   return (
     <RateContentCard
@@ -120,7 +159,11 @@ export const RateContent = ({ variant, area, size }: RateContentProps) => {
             throw new Error();
           }
 
-          toast.success(t('rate-ai-content.toast'));
+          showDialog({
+            title: t('rate-ai-content.toast'),
+            description: t('rate-ai-content.toast-description'),
+            footer: successFooter,
+          });
         } catch {
           toast.error(t('rate-ai-content.toast-error'));
         }

--- a/src/i18n/common/en.json
+++ b/src/i18n/common/en.json
@@ -40,6 +40,7 @@
   "external-link": "The link leads outside the service",
   "feedback": {
     "cancel": "Cancel",
+    "close": "Close",
     "email-label": "E-mail address",
     "error": "Failed to send feedback. Please try again later.",
     "footer-handled": {
@@ -73,6 +74,8 @@
     },
     "submit": "Submit",
     "success": "Thank you for your feedback! Your feedback will help us to improve the service.",
+    "success-description": "Your feedback helps us improve the service.",
+    "success-title": "Thank you for your feedback!",
     "title": "Give feedback",
     "type-question": "What kind of feedback would you like to give?",
     "types": {

--- a/src/i18n/common/fi.json
+++ b/src/i18n/common/fi.json
@@ -40,6 +40,7 @@
   "external-link": "Linkki johtaa palvelun ulkopuolelle",
   "feedback": {
     "cancel": "Peruuta",
+    "close": "Sulje",
     "email-label": "Sähköpostiosoite",
     "error": "Palautteen lähettäminen epäonnistui. Yritä myöhemmin uudelleen.",
     "footer-handled": {
@@ -73,6 +74,8 @@
     },
     "submit": "Lähetä",
     "success": "Kiitos palautteestasi! Palautteesi auttaa meitä parantamaan palvelua.",
+    "success-description": "Palautteesi auttaa meitä parantamaan palvelua.",
+    "success-title": "Kiitos palautteestasi!",
     "title": "Anna palautetta",
     "type-question": "Minkälaista palautetta haluat antaa?",
     "types": {

--- a/src/i18n/common/sv.json
+++ b/src/i18n/common/sv.json
@@ -40,6 +40,7 @@
   "external-link": "Länken leder dig utanför tjänsten",
   "feedback": {
     "cancel": "Avbryt",
+    "close": "Stäng",
     "email-label": "E-postadress",
     "error": "Det gick inte att skicka respons. Försök på nytt senare.",
     "footer-handled": {
@@ -73,6 +74,8 @@
     },
     "submit": "Skicka",
     "success": "Tack för din respons! Din respons hjälper oss att förbättra tjänsten.",
+    "success-description": "Din feedback hjälper oss att förbättra tjänsten.",
+    "success-title": "Tack för din respons!",
     "title": "Ge respons",
     "type-question": "Vilken typ av respons vill du ge?",
     "types": {

--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -720,9 +720,9 @@
         "link-text": "Create goal",
         "title": "Set goals and make plans"
       },
-      "job-and-education-opportunities": "Education and career opportunities",
       "inActiveTag": "Please note",
       "inActiveTagTooltip": "The content suggested by the service has been updated, which means that the description of the saved job opportunity or occupation may have changed. You can still use the information saved as a favorite to create a goal. <CustomLink>Perform a search using the favorite’s title</CustomLink> if you want to save the updated information to your favorites",
+      "job-and-education-opportunities": "Education and career opportunities",
       "link-to-opportunities": "Find opportunities",
       "show-filters": "Show filters",
       "title": "Favourites",
@@ -968,6 +968,7 @@
       "sending": "Submitting"
     },
     "toast": "Thank you for your feedback!",
+    "toast-description": "Your feedback helps us improve the service.",
     "toast-error": "Failed to send feedback – please try again"
   },
   "remove-favorite": "Remove from favourites",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -831,7 +831,7 @@
       "edit-plan-failed": "Suunnitelman päivitys epäonnistui – yritä uudelleen",
       "edit-plan-success": "Suunnitelma päivitetty",
       "favorites-card": {
-        "description": "Tutksustu koulutus- ja työmahdollisuuksiin. Lisää kiinnostavimmat suosikeiksesi ja tee niistä omat tavoitteesi.",
+        "description": "Tutustu koulutus- ja työmahdollisuuksiin. Lisää kiinnostavimmat suosikeiksesi ja tee niistä omat tavoitteesi.",
         "title": "Löydä omat suosikkisi"
       },
       "goal": "Tavoite",
@@ -966,6 +966,7 @@
       "sending": "Lähetetään"
     },
     "toast": "Kiitos palautteesta!",
+    "toast-description": "Palautteesi auttaa meitä parantamaan palvelua.",
     "toast-error": "Palautteen lähettäminen epäonnistui — yritä uudelleen"
   },
   "remove-favorite": "Poista suosikeista",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -967,6 +967,7 @@
       "sending": "Skickar"
     },
     "toast": "Tack för din respons!",
+    "toast-description": "Din feedback hjälper oss att förbättra tjänsten.",
     "toast-error": "Det gick inte att skicka respons – försök igen"
   },
   "remove-favorite": "Ta bort från favoriter",


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Change feedback toast to modal
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2183
