### PR TITLE
OPHJOD-3387: Show error note on authentication failure

### DIFF
--- a/src/i18n/common/en.json
+++ b/src/i18n/common/en.json
@@ -161,6 +161,13 @@
   "required": "mandatory",
   "return-home": "Return to the front page",
   "session": {
+    "auth-error": {
+      "description": "Login failed. Please try again.",
+      "reason": {
+        "method-not-allowed": "The login method you selected is not allowed."
+      },
+      "title": "Login failed"
+    },
     "expired": {
       "continue": "Continue without logging in",
       "login": "Log in again",

--- a/src/i18n/common/fi.json
+++ b/src/i18n/common/fi.json
@@ -160,6 +160,13 @@
   "required": "pakollinen",
   "return-home": "Palaa etusivulle",
   "session": {
+    "auth-error": {
+      "description": "Kirjautuminen ei onnistunut. Yritä uudelleen.",
+      "reason": {
+        "method-not-allowed": "Valitsemasi kirjautumistapa ei ole sallittu."
+      },
+      "title": "Kirjautuminen epäonnistui"
+    },
     "expired": {
       "continue": "Jatka kirjautumatta",
       "login": "Kirjaudu uudelleen",

--- a/src/i18n/common/sv.json
+++ b/src/i18n/common/sv.json
@@ -160,6 +160,13 @@
   "required": "obligatorisk",
   "return-home": "Återgå till förstasidan",
   "session": {
+    "auth-error": {
+      "description": "Inloggningen misslyckades. Försök igen.",
+      "reason": {
+        "method-not-allowed": "Den inloggningsmetod du valde är inte tillåten."
+      },
+      "title": "Inloggningen misslyckades"
+    },
     "expired": {
       "continue": "Fortsätt utan att logga in",
       "login": "Logga in igen",

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -60,10 +60,8 @@ const LanguageButtonWrapper = ({ responsive }: { responsive?: boolean }) => {
 };
 
 const Root = () => {
-  const {
-    t,
-    i18n: { language },
-  } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const language = i18n.language;
   const resetToolStore = useToolStore((state) => state.reset);
   const location = useLocation();
   const { addPermanentNote, removePermanentNote, addTemporaryNote, removeTemporaryNote } = useNoteStack();
@@ -195,6 +193,36 @@ const Root = () => {
       }));
     });
   }, [addTemporaryNote, t, language]);
+
+  // Show a banner when the backend redirects here after a failed login,
+  React.useEffect(() => {
+    const url = new URL(globalThis.location.href);
+    const params = url.searchParams;
+    if (params.get('error') !== 'AUTHENTICATION_FAILURE') {
+      return;
+    }
+    const reason = params.get('reason');
+    const description =
+      reason === 'AUTHENTICATION_METHOD_NOT_ALLOWED'
+        ? t('common:session.auth-error.reason.method-not-allowed')
+        : undefined;
+    // Clean the params from the URL so a reload won't re-show the banner.
+    params.delete('error');
+    params.delete('reason');
+    const query = params.toString();
+    const cleaned = url.pathname + (query ? `?${query}` : '') + url.hash;
+    globalThis.history.replaceState(null, '', cleaned);
+
+    addTemporaryNote(() => ({
+      id: 'auth-error',
+      title: t('common:session.auth-error.title'),
+      description,
+      variant: 'error',
+      isCollapsed: false,
+    }));
+    // Run once on mount; intentionally no dependencies.
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+  }, []);
 
   const { open: openCookieConsent } = useCookieConsent();
 


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
Show error note on authentication failure

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-3387
