### PR TITLE
OPHJOD-3390: Add guided tour for competence identification

### DIFF
--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -698,7 +698,15 @@
       },
       "order-by": "Sort",
       "show-filters": "Show filters",
-      "title": "Competences"
+      "title": "Competences",
+      "tour": {
+        "step-1": {
+          "description": "The service suggests competences to you based on the information you have provided. Select the competences that suit you best. You can also edit your education data at the same time.<br/><br/>Identifying competences improves the relevance of the education and work opportunities suggested to you.",
+          "title": "Identifying competences improves the relevance of search results"
+        },
+        "view-guided-tour": "Tips for identifying competences",
+        "view-guided-tour-label": "Start the guided tour for competence identification"
+      }
     },
     "education-history": {
       "description": "Below you can find your education history. You can add entries to your education history yourself and identify the competencies related to them. You can also import your study records from the national study, education and qualification registers as part of your education history (Studyinfo).",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -696,7 +696,15 @@
       },
       "order-by": "Järjestä",
       "show-filters": "Näytä suodattimet",
-      "title": "Osaamiset"
+      "title": "Osaamiset",
+      "tour": {
+        "step-1": {
+          "description": "Palvelu ehdottaa sinulle antamiesi tietojen perusteella osaamisia. Valitse itsellesi sopivimmat osaamiset. Voit samalla muokata koulutustietoja.<br/><br/>Osaamisten tunnistaminen parantaa sinulle ehdotettavien koulutus- ja työmahdollisuuksien osuvuutta.",
+          "title": "Osaamisten tunnistaminen parantaa hakutulosten osuvuutta"
+        },
+        "view-guided-tour": "Vinkit osaamisten tunnistamiseen",
+        "view-guided-tour-label": "Käynnistä osaamisten tunnistamisen opastettu esittely"
+      }
     },
     "education-history": {
       "description": "Löydät alta koulutushistoriasi. Voit lisätä itse koulutushistoriaasi sekä kartoittaa niihin liittyviä osaamisia. Voit tuoda myös omat opintosuorituksesi valtakunnallisista opinto-, koulutus- ja tutkintorekistereistä osaksi koulutushistoriaasi (Opintopolku).",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -697,7 +697,15 @@
       },
       "order-by": "Sortera",
       "show-filters": "Visa filter",
-      "title": "Kompetenser"
+      "title": "Kompetenser",
+      "tour": {
+        "step-1": {
+          "description": "Tjänsten föreslår kompetenser för dig baserat på den information du har lämnat. Välj de kompetenser som passar dig bäst. Du kan också redigera dina utbildningsuppgifter samtidigt.<br/><br/>Identifiering av kompetenser förbättrar träffsäkerheten i de utbildnings- och arbetsmöjligheter som föreslås för dig.",
+          "title": "Identifiering av kompetenser förbättrar träffsäkerheten i sökresultaten"
+        },
+        "view-guided-tour": "Tips för identifiering av kompetenser",
+        "view-guided-tour-label": "Starta den guidade visningen av kompetensidentifiering"
+      }
     },
     "education-history": {
       "description": "Nedan hittar du din utbildningshistorik. Du kan själv lägga till uppgifter i din utbildningshistorik och kartlägga den kompetens som är kopplad till dem. Du kan också importera dina egna studieprestationer från de nationella studie-, utbildnings- och examensregistren som en del av din utbildningshistorik (Studieinfo).",

--- a/src/routes/Profile/CompetencesTour.tsx
+++ b/src/routes/Profile/CompetencesTour.tsx
@@ -1,0 +1,58 @@
+import { driver, PopoverDOM } from 'driver.js';
+import { createRoot } from 'react-dom/client';
+import { useTranslation } from 'react-i18next';
+
+import { useMediaQueries } from '@jod/design-system';
+import { JodRemove, JodWavingHand, JodWavingHandModified } from '@jod/design-system/icons';
+
+const tour = driver();
+
+export const CompetencesTour = () => {
+  const { t } = useTranslation();
+  const { reduceMotion } = useMediaQueries();
+
+  const startTour = () => {
+    tour.setConfig({
+      animate: !reduceMotion,
+      disableActiveInteraction: true,
+      showButtons: ['close'],
+      doneBtnText: t('tool.tour.buttons.close'),
+      steps: [
+        {
+          element: '#competences-tour-step-1',
+          popover: {
+            title: t('profile.competences.tour.step-1.title'),
+            description: t('profile.competences.tour.step-1.description'),
+            side: 'top',
+            align: 'end',
+          },
+        },
+      ],
+      overlayOpacity: 0.25,
+      onPopoverRender: (popoverDom: PopoverDOM) => {
+        popoverDom.closeButton.ariaLabel = t('close');
+        const root = createRoot(popoverDom.closeButton);
+        root.render(<JodRemove size={18} className="text-white!" />);
+      },
+    });
+    tour.drive();
+  };
+
+  return (
+    <button
+      className="flex cursor-pointer items-center gap-3 rounded-sm bg-bg-gray-2 px-3 py-2 text-accent"
+      onClick={startTour}
+      aria-haspopup="true"
+      aria-label={t('profile.competences.tour.view-guided-tour-label')}
+    >
+      <div className="relative h-6 w-6">
+        <JodWavingHand size={24} className="absolute inset-0 h-full w-full animate-[showA_3s_infinite]" />
+        <JodWavingHandModified
+          size={24}
+          className="absolute inset-0 h-full w-full origin-[35%_75%] animate-[showB_3s_infinite,waveRotate_3s_infinite_ease-in-out]"
+        />
+      </div>
+      <div>{t('profile.competences.tour.view-guided-tour')}</div>
+    </button>
+  );
+};

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -17,6 +17,7 @@ import ImportKoulutusSummaryModal from '@/routes/Profile/EducationHistory/modals
 import { LogoutFormContext } from '@/routes/Root';
 import { useHasToiminto } from '@/stores/useSessionManagerStore';
 
+import { CompetencesTour } from '../CompetencesTour';
 import { ProfileSectionTitle } from '../components';
 import { ProfileNavigationList } from '../components/index';
 import { ToolCard } from '../components/ToolCard';
@@ -272,23 +273,29 @@ const EducationHistory = () => {
           </div>
         )}
 
-        {rows.length === 0 && (
+        {rows.length === 0 ? (
           <div className="mt-6 mb-11" data-testid="education-history-empty-state">
             <EmptyState text={t('profile.education-history.empty')} />
           </div>
+        ) : (
+          <div className="mb-7">
+            <CompetencesTour />
+          </div>
         )}
       </div>
-      <ExperienceTable
-        ariaLabel={title}
-        mainColumnHeader={t('education-history.education-provider-or-education')}
-        addNewNestedLabel={t('education-history.add-studies-to-this-education')}
-        rows={rows}
-        koulutuksetThatNeedUserVerification={koulutuksetThatNeedUserVerification}
-        verifyKoulutusOsaamiset={verifyKoulutusOsaamiset}
-        onRowClick={(row) => guardedAction(onRowClick, row)()}
-        onNestedRowClick={(row) => guardedAction(onNestedRowClick, row)()}
-        onAddNestedRowClick={(row) => guardedAction(onAddNestedRowClick, row)()}
-      />
+      <div id="competences-tour-step-1">
+        <ExperienceTable
+          ariaLabel={title}
+          mainColumnHeader={t('education-history.education-provider-or-education')}
+          addNewNestedLabel={t('education-history.add-studies-to-this-education')}
+          rows={rows}
+          koulutuksetThatNeedUserVerification={koulutuksetThatNeedUserVerification}
+          verifyKoulutusOsaamiset={verifyKoulutusOsaamiset}
+          onRowClick={(row) => guardedAction(onRowClick, row)()}
+          onNestedRowClick={(row) => guardedAction(onNestedRowClick, row)()}
+          onAddNestedRowClick={(row) => guardedAction(onAddNestedRowClick, row)()}
+        />
+      </div>
       <div className="flex space-x-4 px-5 sm:px-6">
         <div className="mb-[84px]">
           <Button

--- a/src/routes/Profile/FreeTimeActivities/FreeTimeActivities.tsx
+++ b/src/routes/Profile/FreeTimeActivities/FreeTimeActivities.tsx
@@ -9,6 +9,7 @@ import { useModal } from '@/hooks/useModal';
 import { useSessionGuardedAction } from '@/hooks/useSessionGuardedAction';
 import { EditVapaaAjanToimintoModal } from '@/routes/Profile/FreeTimeActivities/modals/EditVapaaAjanToimintoModal';
 
+import { CompetencesTour } from '../CompetencesTour';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
 import { ToolCard } from '../components/ToolCard';
 import { FreeTimeActivitiesWizard } from './FreeTimeActivitiesWizard';
@@ -74,24 +75,29 @@ const FreeTimeActivities = () => {
       <div className="px-5 sm:px-6">
         <ProfileSectionTitle type="PATEVYYS" title={title} />
         <p className="mb-7 text-body-lg-mobile sm:text-body-lg">{t('profile.free-time-activities.description')}</p>
-
-        {rows.length === 0 && (
+        {rows.length === 0 ? (
           <div className="mt-6 mb-7" data-testid="free-time-empty-state">
             <EmptyState text={t('profile.free-time-activities.empty')} />
           </div>
+        ) : (
+          <div className="mb-7">
+            <CompetencesTour />
+          </div>
         )}
       </div>
-      <ExperienceTable
-        ariaLabel={title}
-        mainColumnHeader={t('free-time-activities.theme-or-activity')}
-        addNewLabel={t('free-time-activities.add-new-free-time-activity')}
-        addNewNestedLabel={t('free-time-activities.add-new-activity')}
-        rows={rows}
-        onAddClick={guardedAction(showModal, FreeTimeActivitiesWizard)}
-        onRowClick={(row) => guardedAction(onRowClick, row)()}
-        onNestedRowClick={(row) => guardedAction(onNestedRowClick, row)()}
-        onAddNestedRowClick={(row) => guardedAction(onAddNestedRowClick, row)()}
-      />
+      <div id="competences-tour-step-1">
+        <ExperienceTable
+          ariaLabel={title}
+          mainColumnHeader={t('free-time-activities.theme-or-activity')}
+          addNewLabel={t('free-time-activities.add-new-free-time-activity')}
+          addNewNestedLabel={t('free-time-activities.add-new-activity')}
+          rows={rows}
+          onAddClick={guardedAction(showModal, FreeTimeActivitiesWizard)}
+          onRowClick={(row) => guardedAction(onRowClick, row)()}
+          onNestedRowClick={(row) => guardedAction(onNestedRowClick, row)()}
+          onAddNestedRowClick={(row) => guardedAction(onAddNestedRowClick, row)()}
+        />
+      </div>
       {lg ? null : (
         <div className="px-5">
           <ToolCard testId="free-time-go-to-tool" className="mt-6" />

--- a/src/routes/Profile/WorkHistory/WorkHistory.tsx
+++ b/src/routes/Profile/WorkHistory/WorkHistory.tsx
@@ -10,6 +10,7 @@ import { useSessionGuardedAction } from '@/hooks/useSessionGuardedAction';
 import EditTyonantajaModal from '@/routes/Profile/WorkHistory/modals/EditTyonantajaModal';
 import { WorkHistoryWizard } from '@/routes/Profile/WorkHistory/WorkHistoryWizard';
 
+import { CompetencesTour } from '../CompetencesTour';
 import { ProfileNavigationList, ProfileSectionTitle } from '../components';
 import { ToolCard } from '../components/ToolCard';
 import AddOrEditToimenkuvaModal from './modals/AddOrEditToimenkuvaModal';
@@ -76,23 +77,29 @@ const WorkHistory = () => {
         <ProfileSectionTitle type="TOIMENKUVA" title={title} />
         <p className="mb-7 text-body-lg-mobile sm:text-body-lg">{t('profile.work-history.description')}</p>
 
-        {rows.length === 0 && (
+        {rows.length === 0 ? (
           <div className="mt-6 mb-7" data-testid="work-history-empty-state">
             <EmptyState text={t('profile.work-history.empty')} />
           </div>
+        ) : (
+          <div className="mb-7">
+            <CompetencesTour />
+          </div>
         )}
       </div>
-      <ExperienceTable
-        ariaLabel={title}
-        mainColumnHeader={t('work-history.workplace-or-job-description')}
-        addNewLabel={t('work-history.add-new-workplace')}
-        addNewNestedLabel={t('work-history.add-new-job-description')}
-        rows={rows}
-        onAddClick={guardedAction(showModal, WorkHistoryWizard)}
-        onRowClick={(row) => guardedAction(onRowClick, row)()}
-        onNestedRowClick={(row) => guardedAction(onNestedRowClick, row)()}
-        onAddNestedRowClick={(row) => guardedAction(onAddNestedRowClick, row)()}
-      />
+      <div id="competences-tour-step-1">
+        <ExperienceTable
+          ariaLabel={title}
+          mainColumnHeader={t('work-history.workplace-or-job-description')}
+          addNewLabel={t('work-history.add-new-workplace')}
+          addNewNestedLabel={t('work-history.add-new-job-description')}
+          rows={rows}
+          onAddClick={guardedAction(showModal, WorkHistoryWizard)}
+          onRowClick={(row) => guardedAction(onRowClick, row)()}
+          onNestedRowClick={(row) => guardedAction(onNestedRowClick, row)()}
+          onAddNestedRowClick={(row) => guardedAction(onAddNestedRowClick, row)()}
+        />
+      </div>
       {lg ? null : (
         <div className="px-5">
           <ToolCard testId="work-history-go-to-tool" className="mt-6" />


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Add guided tour for competence identification
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3390
