### PR TITLE
OPHJOD-3388: Add tuontiLahde field

### DIFF
--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -970,6 +970,8 @@ export interface components {
       /** Format: uuid */
       id?: string;
       nimi: components['schemas']['LokalisoituTeksti'];
+      /** @enum {string} */
+      tuontiLahde?: 'CV_TUONTI' | 'KOSKI_TUONTI' | 'TMT_TUONTI';
       patevyydet?: components['schemas']['PatevyysDto'][];
     };
     IdDtoUUID: {
@@ -980,6 +982,8 @@ export interface components {
       /** Format: uuid */
       id?: string;
       nimi: components['schemas']['LokalisoituTeksti'];
+      /** @enum {string} */
+      tuontiLahde?: 'CV_TUONTI' | 'KOSKI_TUONTI' | 'TMT_TUONTI';
       toimenkuvat?: components['schemas']['ToimenkuvaDto'][];
     };
     SuosikkiDto: {
@@ -996,6 +1000,8 @@ export interface components {
       /** Format: uuid */
       id?: string;
       nimi: components['schemas']['LokalisoituTeksti'];
+      /** @enum {string} */
+      tuontiLahde?: 'CV_TUONTI' | 'KOSKI_TUONTI' | 'TMT_TUONTI';
       koulutukset?: components['schemas']['KoulutusDto'][];
     };
     JakolinkkiUpdateDto: {
@@ -1249,6 +1255,8 @@ export interface components {
       /** Format: uuid */
       id?: string;
       nimi?: components['schemas']['LokalisoituTeksti'];
+      /** @enum {string} */
+      tuontiLahde?: 'CV_TUONTI' | 'KOSKI_TUONTI' | 'TMT_TUONTI';
       koulutukset?: components['schemas']['KoulutusExportDto'][];
     };
     MuuOsaaminenExportDto: {
@@ -1303,12 +1311,16 @@ export interface components {
       /** Format: uuid */
       id?: string;
       nimi?: components['schemas']['LokalisoituTeksti'];
+      /** @enum {string} */
+      tuontiLahde?: 'CV_TUONTI' | 'KOSKI_TUONTI' | 'TMT_TUONTI';
       patevyydet?: components['schemas']['PatevyysExportDto'][];
     };
     TyopaikkaExportDto: {
       /** Format: uuid */
       id?: string;
       nimi?: components['schemas']['LokalisoituTeksti'];
+      /** @enum {string} */
+      tuontiLahde?: 'CV_TUONTI' | 'KOSKI_TUONTI' | 'TMT_TUONTI';
       toimenkuvat?: components['schemas']['ToimenkuvaExportDto'][];
     };
     YksiloExportDto: {

--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -4,10 +4,12 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Checkbox, cx, Spinner, Tag, useMediaQueries } from '@jod/design-system';
 import { JodCaretDown, JodCaretUp, JodEdit, JodError, JodErrorTriangle } from '@jod/design-system/icons';
 
-import { TooltipWrapper } from '@/components/Tooltip/TooltipWrapper';
+import type { components } from '@/api/schema';
 import { useArrowKeyControls } from '@/hooks/useArrowKeyControls';
 import { useModal } from '@/hooks/useModal';
 import { formatDate, getLocalizedText, sortByProperty } from '@/utils';
+
+import { TooltipWrapper } from '../Tooltip/TooltipWrapper';
 
 export interface ExperienceTableRowData {
   checked?: boolean;
@@ -26,6 +28,12 @@ export interface ExperienceTableRowData {
   }[];
   osaamisetOdottaaTunnistusta?: boolean;
   osaamisetTunnistusEpaonnistui?: boolean;
+  tuontiLahde?:
+    | components['schemas']['TyopaikkaDto']['tuontiLahde']
+    // oxlint-disable-next-line typescript/no-duplicate-type-constituents
+    | components['schemas']['KoulutusKokonaisuusDto']['tuontiLahde']
+    // oxlint-disable-next-line typescript/no-duplicate-type-constituents
+    | components['schemas']['ToimintoDto']['tuontiLahde'];
 }
 
 interface ExperienceTableRowProps {
@@ -56,6 +64,25 @@ interface ExperienceTableRowProps {
   insideModal?: boolean;
 }
 
+const TuontiLahdeTag = ({
+  row,
+  tuontiLahdeLabels,
+}: {
+  row: ExperienceTableRowData;
+  tuontiLahdeLabels: Record<string, string>;
+}) =>
+  row.tuontiLahde && (
+    <div
+      className={cx('font-normal rounded-xl px-4 py-2 font-arial text-[0.875rem] leading-5 text-nowrap', {
+        'bg-secondary-3-light-1 text-black': row.tuontiLahde === 'CV_TUONTI',
+        'bg-secondary-2-dark text-white': row.tuontiLahde === 'KOSKI_TUONTI',
+        'bg-secondary-4-dark-2 text-white': row.tuontiLahde === 'TMT_TUONTI',
+      })}
+    >
+      {tuontiLahdeLabels[row.tuontiLahde]}
+    </div>
+  );
+
 const Title = ({
   nested,
   row,
@@ -65,16 +92,32 @@ const Title = ({
   row: ExperienceTableRowData;
   insideModal?: boolean;
 }) => {
+  const { t } = useTranslation();
   const modalPadding = insideModal ? 'md:pl-6' : 'sm:pl-6';
 
   const text = getLocalizedText(row?.nimi);
   const baseClasses = 'pl-3 sm:pl-5 pr-3 sm:pr-7 pt-2 hyphens-auto [overflow-wrap:anywhere]';
+  const tuontiLahdeLabels = {
+    CV_TUONTI: t('types.tuonti-lahde.CV_TUONTI'),
+    KOSKI_TUONTI: t('types.tuonti-lahde.KOSKI_TUONTI'),
+    TMT_TUONTI: t('types.tuonti-lahde.TMT_TUONTI'),
+  };
 
   if (nested) {
     return <p className={cx(baseClasses, 'font-normal text-body-md sm:py-2', 'pl-5', modalPadding)}>{text}</p>;
   }
   return (
-    <p className={cx(baseClasses, 'font-poppins text-heading-4 sm:pt-1 sm:pb-[3px]', 'pl-5', modalPadding)}>{text}</p>
+    <div
+      className={cx(
+        baseClasses,
+        'flex items-center gap-5 font-poppins text-heading-4 sm:pt-1 sm:pb-[3px]',
+        'pl-5',
+        modalPadding,
+      )}
+    >
+      {text}
+      {<TuontiLahdeTag row={row} tuontiLahdeLabels={tuontiLahdeLabels} />}
+    </div>
   );
 };
 

--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -1303,6 +1303,11 @@
       "OSAAMINEN": "My competences",
       "PATEVYYS": "Recreational activities",
       "TOIMENKUVA": "Workplaces"
+    },
+    "tuonti-lahde": {
+      "CV_TUONTI": "CV",
+      "KOSKI_TUONTI": "Studyinfo",
+      "TMT_TUONTI": "Job Market Finland"
     }
   },
   "update": "Update",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -1301,6 +1301,11 @@
       "OSAAMINEN": "Osaamiseni",
       "PATEVYYS": "Vapaa-ajan toiminnot",
       "TOIMENKUVA": "Työpaikat"
+    },
+    "tuonti-lahde": {
+      "CV_TUONTI": "CV",
+      "KOSKI_TUONTI": "Opintopolku",
+      "TMT_TUONTI": "Työmarkkinatori"
     }
   },
   "update": "Päivitä mahdollisuutesi",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -1303,6 +1303,11 @@
       "OSAAMINEN": "Mina kunskaper",
       "PATEVYYS": "Fritidsaktiviteter",
       "TOIMENKUVA": "Arbetsplatser"
+    },
+    "tuonti-lahde": {
+      "CV_TUONTI": "CV",
+      "KOSKI_TUONTI": "Studieinfo",
+      "TMT_TUONTI": "Jobbmarknaden"
     }
   },
   "update": "Uppdatera",

--- a/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
+++ b/src/routes/Profile/EducationHistory/modals/ImportKoulutusSummaryModal.tsx
@@ -103,6 +103,7 @@ const ImportKoulutusSummaryModal = ({
       .map((entry) => ({ key: entry[0], koulutukset: entry[1] }))
       .map((o, i) => ({
         nimi: JSON.parse(o.key),
+        tuontiLahde: 'KOSKI_TUONTI',
         id: `${i}`,
         koulutukset: o.koulutukset.map((koulutus) => ({
           id: koulutus.id,
@@ -177,11 +178,13 @@ const ImportKoulutusSummaryModal = ({
       const koulutusKokonaisuudet = createKoulutusKokonaisuudet(skipOsaamistenTunnistus);
       const body: {
         nimi: Record<string, string>;
+        tuontiLahde: components['schemas']['KoulutusKokonaisuusDto']['tuontiLahde'];
         koulutukset: Koulutus[];
       }[] = [];
       for (const [jsonNimi, koulutukset] of koulutusKokonaisuudet) {
         body.push({
           nimi: JSON.parse(jsonNimi) as Record<string, string>,
+          tuontiLahde: 'KOSKI_TUONTI',
           koulutukset,
         });
       }

--- a/src/routes/Profile/EducationHistory/utils.ts
+++ b/src/routes/Profile/EducationHistory/utils.ts
@@ -1,3 +1,4 @@
+import type { components } from '@/api/schema';
 import { type ExperienceTableRowData } from '@/components';
 import { sortByProperty } from '@/utils';
 
@@ -16,6 +17,7 @@ export interface Koulutus {
 export interface Koulutuskokonaisuus {
   id?: string;
   nimi: Record<string, string>;
+  tuontiLahde?: components['schemas']['KoulutusKokonaisuusDto']['tuontiLahde'];
   koulutukset: Koulutus[];
 }
 
@@ -53,6 +55,7 @@ export const getEducationHistoryTableRows = (
       nimi: row.nimi,
       alkuPvm: alkuPvm === Number.MAX_SAFE_INTEGER ? undefined : new Date(alkuPvm),
       loppuPvm: loppuPvm === 0 ? undefined : new Date(loppuPvm),
+      tuontiLahde: row.tuontiLahde,
       subrows: [...koulutukset]
         .sort(sortByProperty('alkuPvm'))
         .map((koulutus) => mapKoulutusToRow(koulutus, osaamisetMap)),

--- a/src/routes/Profile/FreeTimeActivities/utils.ts
+++ b/src/routes/Profile/FreeTimeActivities/utils.ts
@@ -1,3 +1,4 @@
+import type { components } from '@/api/schema';
 import { ExperienceTableRowData } from '@/components';
 import { sortByProperty } from '@/utils';
 
@@ -13,6 +14,7 @@ export interface Patevyys {
 export interface VapaaAjanToiminto {
   id?: string;
   nimi: Record<string, string>;
+  tuontiLahde?: components['schemas']['ToimintoDto']['tuontiLahde'];
   patevyydet: Patevyys[];
 }
 
@@ -43,6 +45,7 @@ export const getFreeTimeActivitiesTableRows = (
       nimi: row.nimi,
       alkuPvm: new Date(alkuPvm),
       loppuPvm: loppuPvm === 0 ? undefined : new Date(loppuPvm),
+      tuontiLahde: row.tuontiLahde,
       subrows: [...patevyydet]
         .sort(sortByProperty('alkuPvm'))
         .map((patevyys) => mapPatevyysToRow(patevyys, osaamisetMap)),

--- a/src/routes/Profile/Preferences/CvImport/utils.ts
+++ b/src/routes/Profile/Preferences/CvImport/utils.ts
@@ -38,6 +38,7 @@ const transformKoulutusKokonaisuusDto = (
 ): Koulutuskokonaisuus => ({
   id: dto.id,
   nimi: dto.nimi,
+  tuontiLahde: dto.tuontiLahde,
   koulutukset: (dto.koulutukset || []).map((k) => ({
     id: k.id,
     nimi: k.kuvaus || k.nimi || { fi: '', sv: '', en: '' },
@@ -57,6 +58,7 @@ const transformKoulutusKokonaisuusDto = (
 const transformTyopaikkaDto = (dto: components['schemas']['TyopaikkaDto']): Tyopaikka => ({
   id: dto.id,
   nimi: dto.nimi,
+  tuontiLahde: dto.tuontiLahde,
   toimenkuvat: (dto.toimenkuvat || []).map((t) => ({
     id: t.id,
     nimi: t.nimi,
@@ -112,6 +114,7 @@ const convertActivitiesToTableRows = (
     return {
       key: toiminto.id ?? crypto.randomUUID(),
       nimi: toiminto.nimi,
+      tuontiLahde: toiminto.tuontiLahde,
       subrows: patevyydet.map((p) => ({
         key: p.id ?? crypto.randomUUID(),
         nimi: p.nimi,

--- a/src/routes/Profile/WorkHistory/utils.ts
+++ b/src/routes/Profile/WorkHistory/utils.ts
@@ -1,3 +1,4 @@
+import type { components } from '@/api/schema';
 import { type ExperienceTableRowData } from '@/components';
 import { sortByProperty } from '@/utils';
 
@@ -13,6 +14,7 @@ export interface Toimenkuva {
 export interface Tyopaikka {
   id?: string;
   nimi: Record<string, string>;
+  tuontiLahde?: components['schemas']['TyopaikkaDto']['tuontiLahde'];
   toimenkuvat: Toimenkuva[];
 }
 
@@ -43,6 +45,7 @@ export const getWorkHistoryTableRows = (
       nimi: row.nimi,
       alkuPvm: new Date(alkuPvm),
       loppuPvm: loppuPvm === 0 ? undefined : new Date(loppuPvm),
+      tuontiLahde: row.tuontiLahde,
       checked: true,
       subrows: [...toimenkuvat]
         .sort(sortByProperty('alkuPvm'))


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Add tuontiLahde field
- https://github.com/Opetushallitus/jod-yksilo/pull/270
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3388
