### PR TITLE
OPHJOD-3245: Fix bg color on filters when medium screen size

### DIFF
--- a/src/routes/Profile/Competences/Filters.tsx
+++ b/src/routes/Profile/Competences/Filters.tsx
@@ -14,11 +14,11 @@ interface FiltersProps extends CompetenceFiltersProps {
 
 export const Filters = ({ filterKeys, selectedFilters, setSelectedFilters, groupBy, setGroupBy }: FiltersProps) => {
   const { t } = useTranslation();
-  const { sm } = useMediaQueries();
+  const { lg } = useMediaQueries();
 
   return (
     <>
-      <FilterList title={t('do-filter')} className={sm ? 'bg-bg-gray-2' : 'bg-bg-gray'}>
+      <FilterList title={t('do-filter')} className={lg ? 'bg-bg-gray-2' : 'bg-bg-gray'}>
         <CompetenceFilters
           filterKeys={filterKeys}
           selectedFilters={selectedFilters}
@@ -27,7 +27,7 @@ export const Filters = ({ filterKeys, selectedFilters, setSelectedFilters, group
           showColorIndicator
         />
       </FilterList>
-      <FilterList title={t('profile.competences.order-by')} className={sm ? 'bg-bg-gray-2' : 'bg-bg-gray'}>
+      <FilterList title={t('profile.competences.order-by')} className={lg ? 'bg-bg-gray-2' : 'bg-bg-gray'}>
         <RadioButtonGroup
           value={groupBy}
           onChange={setGroupBy}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
Fix bg color on filters when medium screen size
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
<img width="646" height="559" alt="Screenshot 2026-05-22 at 20 08 47" src="https://github.com/user-attachments/assets/a11ba022-9024-4f8e-bfaf-1768abe5882f" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3245
