### PR TITLE
 Add tooltip for experience table import labels

### DIFF
--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -70,18 +70,30 @@ const TuontiLahdeTag = ({
 }: {
   row: ExperienceTableRowData;
   tuontiLahdeLabels: Record<string, string>;
-}) =>
-  row.tuontiLahde && (
-    <div
-      className={cx('font-normal rounded-xl px-4 py-2 font-arial text-[0.875rem] leading-5 text-nowrap', {
-        'bg-secondary-3-light-1 text-black': row.tuontiLahde === 'CV_TUONTI',
-        'bg-secondary-2-dark text-white': row.tuontiLahde === 'KOSKI_TUONTI',
-        'bg-secondary-4-dark-2 text-white': row.tuontiLahde === 'TMT_TUONTI',
-      })}
-    >
-      {tuontiLahdeLabels[row.tuontiLahde]}
-    </div>
+}) => {
+  const { t } = useTranslation();
+  const tooltipTexts = {
+    CV_TUONTI: t('types.tuonti-lahde.CV_TUONTI_TOOLTIP'),
+    KOSKI_TUONTI: t('types.tuonti-lahde.KOSKI_TUONTI_TOOLTIP'),
+    TMT_TUONTI: t('types.tuonti-lahde.TMT_TUONTI_TOOLTIP'),
+  };
+
+  return (
+    row.tuontiLahde && (
+      <TooltipWrapper
+        tooltipContent={tooltipTexts[row.tuontiLahde]}
+        tooltipPlacement="top"
+        triggerClassName={cx('font-normal rounded-xl px-4 py-2 font-arial text-[0.875rem] leading-5 text-nowrap', {
+          'bg-secondary-3-light-1 text-black': row.tuontiLahde === 'CV_TUONTI',
+          'bg-secondary-2-dark text-white': row.tuontiLahde === 'KOSKI_TUONTI',
+          'bg-secondary-4-dark-2 text-white': row.tuontiLahde === 'TMT_TUONTI',
+        })}
+      >
+        <div>{tuontiLahdeLabels[row.tuontiLahde]}</div>
+      </TooltipWrapper>
+    )
   );
+};
 
 const Title = ({
   nested,

--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -1309,8 +1309,11 @@
     },
     "tuonti-lahde": {
       "CV_TUONTI": "CV",
+      "CV_TUONTI_TOOLTIP": "Imported using CV import",
       "KOSKI_TUONTI": "Studyinfo",
-      "TMT_TUONTI": "Job Market Finland"
+      "KOSKI_TUONTI_TOOLTIP": "Imported from Studyinfo.fi service",
+      "TMT_TUONTI": "Job Market Finland",
+      "TMT_TUONTI_TOOLTIP": "Imported from Job Market Finland service"
     }
   },
   "update": "Update",

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -1307,8 +1307,11 @@
     },
     "tuonti-lahde": {
       "CV_TUONTI": "CV",
+      "CV_TUONTI_TOOLTIP": "Tämä tieto on tuotu käyttäen CV tuontityökalua.",
       "KOSKI_TUONTI": "Opintopolku",
-      "TMT_TUONTI": "Työmarkkinatori"
+      "KOSKI_TUONTI_TOOLTIP": "Tämä tieto on tuotu Opintopolku.fi -palvelusta.",
+      "TMT_TUONTI": "Työmarkkinatori",
+      "TMT_TUONTI_TOOLTIP": "Tämä tieto on tuotu Työmarkkinatori-palvelusta."
     }
   },
   "update": "Päivitä mahdollisuutesi",

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -1309,8 +1309,11 @@
     },
     "tuonti-lahde": {
       "CV_TUONTI": "CV",
+      "CV_TUONTI_TOOLTIP": "Importerad med CV-import",
       "KOSKI_TUONTI": "Studieinfo",
-      "TMT_TUONTI": "Jobbmarknaden"
+      "KOSKI_TUONTI_TOOLTIP": "Importerad från Studieinfo.fi-tjänsten",
+      "TMT_TUONTI": "Jobbmarknaden",
+      "TMT_TUONTI_TOOLTIP": "Importerad från Jobbmarknaden-tjänsten"
     }
   },
   "update": "Uppdatera",


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
Add tooltip for experience table import labels
<img width="740" height="338" alt="Screenshot 2026-06-05 at 15 41 44" src="https://github.com/user-attachments/assets/4685aba9-0232-4f57-bccb-1c06148be5a9" />
<img width="866" height="373" alt="Screenshot 2026-06-05 at 15 41 40" src="https://github.com/user-attachments/assets/d3d78a48-0903-462c-9392-05460c72638f" />



<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3440
