### PR TITLE
OPHJOD-2133: Update color tokens usage

### DIFF
--- a/e2e/EducationHistoryWizard.spec.ts
+++ b/e2e/EducationHistoryWizard.spec.ts
@@ -82,7 +82,7 @@ test('delete educationHistory item', async ({ page }) => {
   // Edit the first item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
   await page.getByRole('button', { name: 'Poista koulutus' }).click();
-  const confirmButton = page.locator('button.ds\\:bg-alert', { hasText: 'Poista koulutus' }).last();
+  const confirmButton = page.locator('button.ds\\:bg-alert-1', { hasText: 'Poista koulutus' }).last();
   await expect(confirmButton).toBeVisible();
 
   const [request] = await Promise.all([

--- a/e2e/FreeTimeActivitiesWizard.spec.ts
+++ b/e2e/FreeTimeActivitiesWizard.spec.ts
@@ -84,7 +84,7 @@ test('delete freetime activity item', async ({ page }) => {
   // Edit the first item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
   await page.getByRole('button', { name: 'Poista teema' }).click();
-  const confirmButton = page.locator('button.ds\\:bg-alert', { hasText: 'Poista' }).last();
+  const confirmButton = page.locator('button.ds\\:bg-alert-1', { hasText: 'Poista' }).last();
   await expect(confirmButton).toBeVisible();
 
   const [request] = await Promise.all([

--- a/e2e/WorkHistoryWizard.spec.ts
+++ b/e2e/WorkHistoryWizard.spec.ts
@@ -79,7 +79,7 @@ test('delete workhistory item', async ({ page }) => {
   // Edit the first work history item
   await page.getByRole('button', { name: 'Muokkaa' }).first().click();
   await page.getByRole('button', { name: 'Poista työpaikka' }).click();
-  const confirmButton = page.locator('button.ds\\:bg-alert', { hasText: 'Poista työpaikka' }).last();
+  const confirmButton = page.locator('button.ds\\:bg-alert-1', { hasText: 'Poista työpaikka' }).last();
   await expect(confirmButton).toBeVisible();
 
   const [request] = await Promise.all([

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.4.0",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
         "driver.js": "1.4.0",
         "i18next": "26.2.0",
         "i18next-http-backend": "4.0.0",
@@ -917,8 +917,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-cetrI/nJusi4GI5mo7OGmywa3wXBOLFltPIA4vFUqSrdhmqBJAXywAowcHHP4XdKnytE0ozLTKKcaD5MTblKDA==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-QR5I89D2wvaR9bq5p/HS+1iiOILF6S+Az/7oG77TokT5TVhZSgtVpeDI20QrOoAHca4d1JqepXcfgKuYsixozg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.36.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.4.0",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
     "driver.js": "1.4.0",
     "i18next": "26.2.0",
     "i18next-http-backend": "4.0.0",

--- a/src/components/CompareTable/CompareCompetencesTableRow.tsx
+++ b/src/components/CompareTable/CompareCompetencesTableRow.tsx
@@ -48,7 +48,7 @@ export const CompareCompetencesTableRow = ({ row, className }: CompareCompetence
       <td className="justify-items-center pr-5">
         {row.profiili && (
           <>
-            <div role="img" aria-label={t('found')} className="size-4 rounded-full bg-secondary-1" />
+            <div role="img" aria-label={t('found')} className="size-4 rounded-full bg-primary-1" />
             <div aria-hidden className="hidden print:block">
               {t('found')}
             </div>

--- a/src/components/CounselingCard/CounselingCard.tsx
+++ b/src/components/CounselingCard/CounselingCard.tsx
@@ -16,7 +16,7 @@ export const CounselingCard = () => {
   const link = links[i18n.language] || links.fi;
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg bg-secondary-2-dark p-6 text-white">
+    <div className="flex flex-col gap-3 rounded-lg bg-primary-2-dark p-6 text-white">
       <h2 className="text-heading-2">{t('service-catalog.header')}</h2>
       <div className="flex flex-col gap-6">
         <p className="text-body-lg">{t('service-catalog.description')}</p>

--- a/src/components/ExperienceTable/ExperienceTableRow.tsx
+++ b/src/components/ExperienceTable/ExperienceTableRow.tsx
@@ -84,9 +84,9 @@ const TuontiLahdeTag = ({
         tooltipContent={tooltipTexts[row.tuontiLahde]}
         tooltipPlacement="top"
         triggerClassName={cx('font-normal rounded-xl px-4 py-2 font-arial text-[0.875rem] leading-5 text-nowrap', {
-          'bg-secondary-3-light-1 text-black': row.tuontiLahde === 'CV_TUONTI',
-          'bg-secondary-2-dark text-white': row.tuontiLahde === 'KOSKI_TUONTI',
-          'bg-secondary-4-dark-2 text-white': row.tuontiLahde === 'TMT_TUONTI',
+          'bg-primary-3-light-1 text-black': row.tuontiLahde === 'CV_TUONTI',
+          'bg-primary-2-dark text-white': row.tuontiLahde === 'KOSKI_TUONTI',
+          'bg-primary-4-dark-2 text-white': row.tuontiLahde === 'TMT_TUONTI',
         })}
       >
         <div>{tuontiLahdeLabels[row.tuontiLahde]}</div>
@@ -244,7 +244,7 @@ export const ExperienceTableRow = ({
     return (
       <div className="flex items-center justify-start">
         <TooltipWrapper tooltipContent={t('competences-identify-failed')} tooltipPlacement="top">
-          <JodErrorTriangle className="text-alert" />
+          <JodErrorTriangle className="text-alert-1" />
         </TooltipWrapper>
       </div>
     );
@@ -273,7 +273,7 @@ export const ExperienceTableRow = ({
 
   const triggerClassName = React.useMemo(
     () =>
-      `cursor-pointer flex size-7 items-center justify-center rounded-full mr-2 sm:m-3 ${isOdd ? 'hover:bg-secondary-5-light-3 active:bg-secondary-5-light-3' : 'hover:bg-bg-gray-2 active:bg-bg-gray-2'}`,
+      `cursor-pointer flex size-7 items-center justify-center rounded-full mr-2 sm:m-3 ${isOdd ? 'hover:bg-primary-5-light-3 active:bg-primary-5-light-3' : 'hover:bg-bg-gray-2 active:bg-bg-gray-2'}`,
     [isOdd],
   );
 
@@ -370,7 +370,7 @@ export const ExperienceTableRow = ({
               tooltipPlacement="top"
             >
               <span>
-                <JodError className="text-secondary-3!" />
+                <JodError className="text-primary-3!" />
               </span>
             </TooltipWrapper>
           )}

--- a/src/components/FilterList/FilterList.tsx
+++ b/src/components/FilterList/FilterList.tsx
@@ -12,7 +12,7 @@ export const FilterList = ({
   title,
   collapsible = false,
   children,
-  className = 'bg-secondary-1-25',
+  className = 'bg-bg-gray-2',
   headingLevel,
 }: FilterListProps) => {
   const TitleTag = headingLevel ?? 'h2';

--- a/src/components/FormError/FormError.tsx
+++ b/src/components/FormError/FormError.tsx
@@ -19,7 +19,10 @@ export const FormError = ({ name, errors }: FormErrorProps) =>
       name={name}
       errors={errors}
       render={({ message }) => (
-        <span className="font-arial text-form-error text-alert" data-testid={`form-error-${name.replace(/\./g, '-')}`}>
+        <span
+          className="font-arial text-form-error text-alert-1"
+          data-testid={`form-error-${name.replace(/\./g, '-')}`}
+        >
           {message}
         </span>
       )}

--- a/src/components/HowToUse/HowToUse.tsx
+++ b/src/components/HowToUse/HowToUse.tsx
@@ -134,7 +134,7 @@ export function HowToUse() {
 
   return (
     <figure className="flex flex-col items-center justify-center">
-      <div className="rounded-2xl max-w-lg border-4 border-secondary-1-light-3 bg-white px-4 py-2 pb-4">
+      <div className="rounded-2xl max-w-lg border-4 border-primary-1-light-3 bg-white px-4 py-2 pb-4">
         <div className="flex flex-1 flex-col">
           <div className="mb-3 flex items-end gap-3">
             {osaamispolkuLogo}
@@ -142,7 +142,7 @@ export function HowToUse() {
               / {t('common:navigation.external.yksilo.label')}
             </div>
           </div>
-          <div className="font-semibold flex items-center justify-center rounded-md bg-secondary-1-dark p-5 text-body-sm text-white">
+          <div className="font-semibold flex items-center justify-center rounded-md bg-primary-1-dark p-5 text-body-sm text-white">
             <span className="mr-3">{t('how-to-use.find-opportunities-title')}</span>
             <Tooltip>
               <TooltipTrigger aria-label={t('common:more-info')} aria-describedby={findOpportunitiesId}>
@@ -173,7 +173,7 @@ export function HowToUse() {
           <div className="flex flex-col items-center">
             <BlueArrows />
             <div className="font-semibold flex flex-1 flex-row gap-3 text-center text-body-xs text-[0.625rem] text-primary-gray sm:text-left sm:text-[0.75rem]">
-              <div className="flex flex-1 flex-col items-center justify-between gap-2 rounded-md bg-secondary-1-light-2 p-4 sm:flex-row">
+              <div className="flex flex-1 flex-col items-center justify-between gap-2 rounded-md bg-primary-1-light-2 p-4 sm:flex-row">
                 {t('how-to-use.find-opportunities-without-login-title')}
                 <Tooltip>
                   <TooltipTrigger aria-label={t('common:more-info')} aria-describedby={findOpportunitiesWithoutLoginId}>
@@ -185,7 +185,7 @@ export function HowToUse() {
                   </TooltipContent>
                 </Tooltip>
               </div>
-              <div className="flex flex-1 flex-col items-center justify-between gap-2 rounded-md bg-secondary-1-light-1 p-4 sm:flex-row">
+              <div className="flex flex-1 flex-col items-center justify-between gap-2 rounded-md bg-primary-1-light-1 p-4 sm:flex-row">
                 {t('how-to-use.create-profile-title')}
                 <Tooltip>
                   <TooltipTrigger aria-label={t('common:more-info')} aria-describedby={createProfileId}>
@@ -197,7 +197,7 @@ export function HowToUse() {
                   </TooltipContent>
                 </Tooltip>
               </div>
-              <div className="flex flex-1 flex-col items-center justify-between gap-2 rounded-md bg-secondary-1-light-2 p-4 sm:flex-row">
+              <div className="flex flex-1 flex-col items-center justify-between gap-2 rounded-md bg-primary-1-light-2 p-4 sm:flex-row">
                 {t('how-to-use.find-with-words-title')}
                 <Tooltip>
                   <TooltipTrigger aria-label={t('common:more-info')} aria-describedby={findWithWordsId}>
@@ -216,11 +216,11 @@ export function HowToUse() {
       <div className="relative -top-5 flex flex-col items-center">
         <GrayArrows />
         <div className="font-semibold flex flex-row gap-3 text-center text-body-xs text-[0.625rem] text-primary-gray sm:text-[0.75rem]">
-          <div className="flex w-[120px] flex-1 flex-col items-center justify-center gap-3 rounded-md bg-primary-light-2 p-5 sm:w-[150px]">
+          <div className="flex w-[120px] flex-1 flex-col items-center justify-center gap-3 rounded-md bg-primary-5-light-2 p-5 sm:w-[150px]">
             {t('how-to-use.job-seeker-profile')}
             <div className="flex items-center">{tyomarkkinatoriLogo}</div>
           </div>
-          <div className="flex w-[120px] flex-1 flex-col items-center justify-center gap-3 rounded-md bg-primary-light-2 p-5 sm:w-[150px]">
+          <div className="flex w-[120px] flex-1 flex-col items-center justify-center gap-3 rounded-md bg-primary-5-light-2 p-5 sm:w-[150px]">
             {t('how-to-use.education-history')}
             <div className="flex items-center">{opintopolkuLogo}</div>
           </div>

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -11,7 +11,7 @@ export const InfoBox = ({ text }: InfoBoxProps) => {
   return (
     <section
       aria-label={t('tooltip.info')}
-      className="max-w-xl mb-8 flex items-start gap-4 rounded-md bg-bg-gray-2 py-5 pr-6 pl-4 text-heading-4 text-secondary-1-dark-2"
+      className="max-w-xl mb-8 flex items-start gap-4 rounded-md bg-bg-gray-2 py-5 pr-6 pl-4 text-heading-4 text-primary-1-dark-2"
     >
       <div aria-hidden="true">
         <JodInfo />

--- a/src/components/OpportunityCard/EducationOpportunityCard.tsx
+++ b/src/components/OpportunityCard/EducationOpportunityCard.tsx
@@ -44,7 +44,7 @@ export const EducationOpportunityCard = ({ kesto, yleisinKoulutusala, ...rest }:
                 </div>
               }
             >
-              <JodInfo size={18} className="text-secondary-5-light-1" />
+              <JodInfo size={18} className="text-primary-5-light-1" />
             </TooltipWrapper>
           }
         />
@@ -60,7 +60,7 @@ export const EducationOpportunityCard = ({ kesto, yleisinKoulutusala, ...rest }:
                 </div>
               }
             >
-              <JodInfo size={18} className="text-secondary-5-light-1" />
+              <JodInfo size={18} className="text-primary-5-light-1" />
             </TooltipWrapper>
           }
         />

--- a/src/components/OpportunityCard/JobOpportunityCard.tsx
+++ b/src/components/OpportunityCard/JobOpportunityCard.tsx
@@ -53,7 +53,7 @@ export const JobOpportunityCard = ({ ammattiryhmaNimet, ammattiryhma, ...rest }:
                   </div>
                 }
               >
-                <JodInfo size={18} className="text-secondary-5-light-1" />
+                <JodInfo size={18} className="text-primary-5-light-1" />
               </TooltipWrapper>
             }
           />
@@ -73,7 +73,7 @@ export const JobOpportunityCard = ({ ammattiryhmaNimet, ammattiryhma, ...rest }:
                   </div>
                 }
               >
-                <JodInfo size={18} className="text-secondary-5-light-1" />
+                <JodInfo size={18} className="text-primary-5-light-1" />
               </TooltipWrapper>
             }
           />
@@ -89,7 +89,7 @@ export const JobOpportunityCard = ({ ammattiryhmaNimet, ammattiryhma, ...rest }:
                   </div>
                 }
               >
-                <JodInfo size={18} className="text-secondary-5-light-1" />
+                <JodInfo size={18} className="text-primary-5-light-1" />
               </TooltipWrapper>
             }
           />

--- a/src/components/OpportunityCard/OpportunityCard.tsx
+++ b/src/components/OpportunityCard/OpportunityCard.tsx
@@ -301,10 +301,9 @@ const OpportunityCardHeader = ({
   const TitleTag = headingLevel || 'span';
   const { sm } = useMediaQueries();
 
-  const bgColorClassName =
-    mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'bg-secondary-2-dark' : 'bg-secondary-4-dark-2';
+  const bgColorClassName = mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'bg-primary-2-dark' : 'bg-primary-4-dark-2';
   const textColorClassName =
-    mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'text-secondary-2-dark' : 'text-secondary-4-dark-2';
+    mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'text-primary-2-dark' : 'text-primary-4-dark-2';
 
   const titleContent = (
     <>

--- a/src/components/OpportunityCard/components/OpportunityDetail.tsx
+++ b/src/components/OpportunityCard/components/OpportunityDetail.tsx
@@ -11,7 +11,7 @@ export const OpportunityDetail = ({ title, value, icon }: OpportunityDetailProps
         <span>{title}</span>
         {icon}
       </div>
-      <div className="text-heading-3 text-secondary-1-dark">{value}</div>
+      <div className="text-heading-3 text-primary-1-dark">{value}</div>
     </div>
   );
 };

--- a/src/components/OpportunityCard/components/OpportunityDetailsWrapper.tsx
+++ b/src/components/OpportunityCard/components/OpportunityDetailsWrapper.tsx
@@ -1,3 +1,3 @@
 export const OpportunityDetailsWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className="flex flex-col gap-y-3 border-l-2 border-border-form pl-4">{children}</div>;
+  return <div className="border-border-form flex flex-col gap-y-3 border-l-2 pl-4">{children}</div>;
 };

--- a/src/components/OpportunityDetails/OpportunityDetails.tsx
+++ b/src/components/OpportunityDetails/OpportunityDetails.tsx
@@ -213,10 +213,9 @@ const OpportunityHeader = ({
   mahdollisuusAlityyppi,
   showAiInfoInTitle = false,
 }: OpportunityHeaderProps) => {
-  const bgColorClassName =
-    mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'bg-secondary-2-dark' : 'bg-secondary-4-dark-2';
+  const bgColorClassName = mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'bg-primary-2-dark' : 'bg-primary-4-dark-2';
   const textColorClassName =
-    mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'text-secondary-2-dark' : 'text-secondary-4-dark-2';
+    mahdollisuusTyyppi === 'KOULUTUSMAHDOLLISUUS' ? 'text-primary-2-dark' : 'text-primary-4-dark-2';
   return (
     <div className="flex flex-row">
       <div

--- a/src/components/OpportunityType/OpportunityType.tsx
+++ b/src/components/OpportunityType/OpportunityType.tsx
@@ -85,7 +85,7 @@ export const OpportunityType = ({ mahdollisuusAlityyppi, showTypeTooltip }: Oppo
       {typeText}
       {showTypeTooltip && (
         <TooltipWrapper tooltipPlacement="top" tooltipContent={typeTooltip}>
-          <JodInfo size={18} className="text-secondary-5-light-1" />
+          <JodInfo size={18} className="text-primary-5-light-1" />
         </TooltipWrapper>
       )}
     </div>

--- a/src/components/RateContent/RateContent.tsx
+++ b/src/components/RateContent/RateContent.tsx
@@ -169,7 +169,7 @@ export const RateContent = ({ variant, area, size }: RateContentProps) => {
         }
       }}
       size={size}
-      className={variant === 'ammatti' ? 'bg-secondary-1-dark-2!' : undefined}
+      className={variant === 'ammatti' ? 'bg-primary-1-dark-2!' : undefined}
       testId="rate-content"
     />
   );

--- a/src/components/VirtualAssistant/components/VirtualAssistantMessageBubble.tsx
+++ b/src/components/VirtualAssistant/components/VirtualAssistantMessageBubble.tsx
@@ -5,7 +5,7 @@ export const VirtualAssistantMessageBubble = ({ message, isUser }: { message: st
     <div className={cx('relative flex', isUser ? 'justify-end' : 'justify-start')}>
       {isUser ? (
         <div
-          className="absolute right-0 -bottom-3 h-0 w-0 border-8 border-l-0 border-secondary-1-light-3 border-t-transparent border-b-transparent"
+          className="absolute right-0 -bottom-3 h-0 w-0 border-8 border-l-0 border-primary-1-light-3 border-t-transparent border-b-transparent"
           aria-hidden
         />
       ) : (
@@ -17,7 +17,7 @@ export const VirtualAssistantMessageBubble = ({ message, isUser }: { message: st
       <div
         className={cx(
           'w-fit max-w-full rounded px-5 py-4 text-body-sm-mobile wrap-break-word whitespace-pre-wrap sm:max-w-[calc(100%-50px)] sm:text-body-sm',
-          isUser ? 'bg-secondary-1-light-3' : 'bg-bg-gray',
+          isUser ? 'bg-primary-1-light-3' : 'bg-bg-gray',
         )}
       >
         {message}

--- a/src/routes/Cv/Cv.tsx
+++ b/src/routes/Cv/Cv.tsx
@@ -31,7 +31,7 @@ const BasicInfoDetail = ({ data, title }: { data?: string | number; title: strin
   data ? (
     <div className="flex flex-wrap">
       <dt className="after:mr-2 after:content-[':']">{title}</dt>
-      <dd className="text-secondary-1-dark-2">{`${data}`}</dd>
+      <dd className="text-primary-1-dark-2">{`${data}`}</dd>
     </div>
   ) : null;
 
@@ -136,7 +136,7 @@ const Cv = () => {
     />
   );
   const osaamispolkuBox = (
-    <div className="mx-5 flex flex-col gap-5 rounded-lg bg-secondary-1-dark-2 p-6 sm:mx-6 lg:mx-0 print:hidden">
+    <div className="mx-5 flex flex-col gap-5 rounded-lg bg-primary-1-dark-2 p-6 sm:mx-6 lg:mx-0 print:hidden">
       <div className="mr-2 text-heading-2 text-white">{t('common:osaamispolku')}</div>
       <p className="text-body-lg text-white">{t('cv.osaamispolku-description')}</p>
       <div className="mt-4">
@@ -213,7 +213,7 @@ const Cv = () => {
           />
           <div className="mb-6 flex flex-row rounded-md bg-bg-gray-2 p-5">
             <div className="shrink items-start pr-5">
-              <JodInfo className="text-secondary-1-dark-2" />
+              <JodInfo className="text-primary-1-dark-2" />
             </div>
             <dl className="flex flex-col flex-wrap text-heading-4-mobile sm:text-heading-4">
               <BasicInfoDetail data={personName} title={t('cv.basic-info.person')} />

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -118,7 +118,7 @@ const Home = () => {
           titleLevel={1}
           titleClassName="text-hero-mobile sm:text-hero focus:outline-0"
           content={t('home.hero-content')}
-          backgroundColor="var(--ds-color-secondary-1-dark-2)"
+          backgroundColor="var(--ds-color-primary-1-dark-2)"
         />
       </CardContainer>
       <CardContainer>
@@ -130,7 +130,7 @@ const Home = () => {
           title={t('home.card-1-title')}
           to={toolLink}
           textColor="var(--ds-color-primary-gray)"
-          backgroundColor="var(--ds-color-secondary-1-light-2)"
+          backgroundColor="var(--ds-color-primary-1-light-2)"
         />
         <HeroCard
           buttonLabel={isLoggedIn ? t('profile.banner.link-text.logged-in') : t('home.create-own-profile')}
@@ -140,7 +140,7 @@ const Home = () => {
           title={isLoggedIn ? t('profile.banner.title.logged-in') : t('home.card-2-title')}
           to={t('slugs.profile.index')}
           textColor="var(--ds-color-primary-gray)"
-          backgroundColor="var(--ds-color-secondary-1-light-1)"
+          backgroundColor="var(--ds-color-primary-1-light-1)"
         />
       </CardContainer>
 
@@ -182,7 +182,7 @@ const Home = () => {
             title={t('home.personal-guidance.title')}
             buttonLabel={t('home.personal-guidance.link-text')}
             to={t('common:navigation.extra.palveluhakemisto.url')}
-            backgroundColor="var(--ds-color-secondary-2-dark)"
+            backgroundColor="var(--ds-color-primary-2-dark)"
             linkComponent={getLinkTo(t('common:navigation.extra.palveluhakemisto.url'), {
               useAnchor: true,
               target: '_blank',

--- a/src/routes/Profile/Competences/CompetenceFilters.tsx
+++ b/src/routes/Profile/Competences/CompetenceFilters.tsx
@@ -16,10 +16,10 @@ interface TitleCheckboxProps {
 
 const getFilterColorClassName = (type: keyof FiltersType) =>
   cx({
-    'bg-secondary-4': type === 'TOIMENKUVA',
-    'bg-secondary-2': type === 'KOULUTUS',
-    'bg-secondary-1': type === 'PATEVYYS',
-    'bg-secondary-5-light-1': type === 'MUU_OSAAMINEN',
+    'bg-primary-4': type === 'TOIMENKUVA',
+    'bg-primary-2': type === 'KOULUTUS',
+    'bg-primary-1': type === 'PATEVYYS',
+    'bg-primary-5-light-1': type === 'MUU_OSAAMINEN',
   });
 /**
  * This component is used as the top level filter title. It toggles all filters of a specific type.

--- a/src/routes/Profile/EducationHistory/EducationHistory.tsx
+++ b/src/routes/Profile/EducationHistory/EducationHistory.tsx
@@ -267,7 +267,7 @@ const EducationHistory = () => {
 
         {koulutuksetThatNeedUserVerification.length > 0 && (
           <div className="mb-5 flex w-fit items-center rounded-md bg-bg-gray-2 px-5 py-3">
-            <JodError className="mr-3 text-secondary-3" />
+            <JodError className="mr-3 text-primary-3" />
             <span className="font-arial text-body-sm text-primary-gray">
               {t('education-history.check-identified-osaamiset')}
             </span>

--- a/src/routes/Profile/Favorites/Favorites.tsx
+++ b/src/routes/Profile/Favorites/Favorites.tsx
@@ -35,7 +35,7 @@ const GoalsCard = ({ testId, className = '' }: { testId: string; className?: str
 
   return (
     <div
-      className={tc(`flex flex-col gap-3 rounded-lg bg-secondary-1-dark-2 p-6 text-white ${className}`)}
+      className={tc(`flex flex-col gap-3 rounded-lg bg-primary-1-dark-2 p-6 text-white ${className}`)}
       data-testid={testId}
     >
       <h2 className="text-heading-2-mobile sm:text-heading-2">{t('profile.favorites.goals-card.title')}</h2>

--- a/src/routes/Profile/MyGoals/MyGoals.tsx
+++ b/src/routes/Profile/MyGoals/MyGoals.tsx
@@ -22,7 +22,7 @@ const GuidanceCard = ({ testId, className = '' }: { testId: string; className?: 
 
   return (
     <div
-      className={tidyClasses(`flex flex-col gap-3 rounded-lg bg-secondary-1-dark-2 p-6 text-white ${className}`)}
+      className={tidyClasses(`flex flex-col gap-3 rounded-lg bg-primary-1-dark-2 p-6 text-white ${className}`)}
       data-testid={testId}
     >
       <h2 className="text-heading-2">{t('home.need-personal-guidance')}</h2>

--- a/src/routes/Profile/MyGoals/addGoal/GoalModal.tsx
+++ b/src/routes/Profile/MyGoals/addGoal/GoalModal.tsx
@@ -273,7 +273,7 @@ export const GoalModal = ({ mode, tavoite, ...rest }: GoalModalProps) => {
                                   'flex',
                                   'items-center',
                                   'justify-center',
-                                  'bg-secondary-3',
+                                  'bg-primary-3',
                                   'text-primary-gray',
                                   'text-heading-4',
                                   'rounded',

--- a/src/routes/Profile/MyGoals/addPlan/AddPlanModal.tsx
+++ b/src/routes/Profile/MyGoals/addPlan/AddPlanModal.tsx
@@ -207,7 +207,7 @@ const AddPlanModal = ({ onClose, ...rest }: ModalComponentProps) => {
                                   'flex',
                                   'items-center',
                                   'justify-center',
-                                  'bg-secondary-3',
+                                  'bg-primary-3',
                                   'text-primary-gray',
                                   'text-heading-4',
                                   'rounded',

--- a/src/routes/Profile/MyGoals/addPlan/selectPlan/PlanOpportunityCard.tsx
+++ b/src/routes/Profile/MyGoals/addPlan/selectPlan/PlanOpportunityCard.tsx
@@ -33,9 +33,9 @@ const PlanOpportunityCard = React.memo(
     const { otsikko, kuvaus } = mahdollisuus;
     const missingOsaamisetUris = new Set(vaaditutOsaamiset.map((o) => o.uri));
 
-    const bgColorClassName = mahdollisuus.tyyppi === 'EI_TUTKINTO' ? 'bg-secondary-2-dark' : 'bg-secondary-4-dark-2';
+    const bgColorClassName = mahdollisuus.tyyppi === 'EI_TUTKINTO' ? 'bg-primary-2-dark' : 'bg-primary-4-dark-2';
     const textColorClassName =
-      mahdollisuus.tyyppi === 'EI_TUTKINTO' ? 'text-secondary-2-dark!' : 'text-secondary-4-dark-2!';
+      mahdollisuus.tyyppi === 'EI_TUTKINTO' ? 'text-primary-2-dark!' : 'text-primary-4-dark-2!';
 
     const fetchOsaamiset = () =>
       client

--- a/src/routes/Profile/MyGoals/compareCompetences/PlanCompetenceRow.tsx
+++ b/src/routes/Profile/MyGoals/compareCompetences/PlanCompetenceRow.tsx
@@ -57,9 +57,9 @@ export const PlanCompetenceRow = ({ row, className }: CompareCompetencesTableRow
       <td className="w-full py-3 pr-7 pl-5 text-heading-5 hyphens-auto first-letter:uppercase">
         {getLocalizedText(row.nimi)}
       </td>
-      <FoundOrEmptyCell key="profile" found={row.profiili} bgClass="bg-secondary-1" />
+      <FoundOrEmptyCell key="profile" found={row.profiili} bgClass="bg-primary-1" />
       {row.plans.map((hasOsaaminen, index) => (
-        <FoundOrEmptyCell key={`plan${index}`} found={hasOsaaminen} bgClass="bg-secondary-2" addBorder />
+        <FoundOrEmptyCell key={`plan${index}`} found={hasOsaaminen} bgClass="bg-primary-2" addBorder />
       ))}
     </tr>
   );

--- a/src/routes/Profile/Preferences/ShareLinkSection/ShareLinkSection.tsx
+++ b/src/routes/Profile/Preferences/ShareLinkSection/ShareLinkSection.tsx
@@ -79,7 +79,7 @@ const ShareLinkSection = ({ className }: ShareLinkSectionProps) => {
               const expired = date ? date < new Date() : false;
               const dateStr = date ? formatDate(date, 'medium') : null;
               const expirationText = expired ? (
-                <div className="text-button-sm text-alert-text-2">{t('preferences.share.link-has-expired')}</div>
+                <div className="text-button-sm text-alert-2">{t('preferences.share.link-has-expired')}</div>
               ) : (
                 <div className="text-button-sm">{t('preferences.share.valid-until', { date: dateStr })}</div>
               );

--- a/src/routes/Profile/components/ProfileSectionTitle.tsx
+++ b/src/routes/Profile/components/ProfileSectionTitle.tsx
@@ -28,12 +28,12 @@ export const ProfileSectionTitle = ({ type, title }: { type: ProfileSectionType;
   };
 
   const iconBg = cx({
-    'bg-secondary-4-dark': type === 'TOIMENKUVA',
-    'bg-secondary-2-dark': type === 'KOULUTUS',
-    'bg-secondary-1-dark': type === 'PATEVYYS',
+    'bg-primary-4-dark': type === 'TOIMENKUVA',
+    'bg-primary-2-dark': type === 'KOULUTUS',
+    'bg-primary-1-dark': type === 'PATEVYYS',
     'bg-secondary-gray': type === 'MUU_OSAAMINEN',
-    'bg-secondary-3': type === 'KIINNOSTUS',
-    'bg-secondary-1-dark-2': ['SUOSIKKI', 'OSAAMISENI', 'TAVOITTEENI', 'ASETUKSENI'].includes(type),
+    'bg-primary-3': type === 'KIINNOSTUS',
+    'bg-primary-1-dark-2': ['SUOSIKKI', 'OSAAMISENI', 'TAVOITTEENI', 'ASETUKSENI'].includes(type),
   });
 
   const showIcon = type && iconMap[type] !== null;

--- a/src/routes/Profile/components/ToolCard.tsx
+++ b/src/routes/Profile/components/ToolCard.tsx
@@ -36,7 +36,7 @@ export const ToolCard = ({
     : `/${i18n.language}/${t('slugs.tool.index')}`;
 
   return (
-    <div className={tc(`flex flex-col gap-5 rounded-lg bg-secondary-1-dark-2 p-6 ${className}`)}>
+    <div className={tc(`flex flex-col gap-5 rounded-lg bg-primary-1-dark-2 p-6 ${className}`)}>
       <h2 className="mr-2 text-heading-2-mobile text-white sm:text-heading-2">{title ?? t('tool.banner.title')}</h2>
       <p className="text-body-lg-mobile text-white sm:text-body-lg">{description ?? t('tool.banner.description')}</p>
       <div className="mt-4">

--- a/src/routes/Profile/utils.tsx
+++ b/src/routes/Profile/utils.tsx
@@ -80,10 +80,10 @@ export type ProfileSectionType =
 
 export const getTextClassByCompetenceSourceType = (type: ProfileSectionType) =>
   cx({
-    'text-secondary-4-dark': type === 'TOIMENKUVA',
-    'text-secondary-2-dark': type === 'KOULUTUS',
-    'text-secondary-1-dark': type === 'PATEVYYS',
+    'text-primary-4-dark': type === 'TOIMENKUVA',
+    'text-primary-2-dark': type === 'KOULUTUS',
+    'text-primary-1-dark': type === 'PATEVYYS',
     'text-secondary-gray': type === 'MUU_OSAAMINEN',
-    'text-secondary-3': type === 'KIINNOSTUS',
-    'text-secondary-1-dark-2': ['SUOSIKKI', 'OSAAMISENI', 'TAVOITTEENI', 'ASETUKSENI'].includes(type),
+    'text-primary-3': type === 'KIINNOSTUS',
+    'text-primary-1-dark-2': ['SUOSIKKI', 'OSAAMISENI', 'TAVOITTEENI', 'ASETUKSENI'].includes(type),
   });

--- a/src/routes/Search/InfoCards.tsx
+++ b/src/routes/Search/InfoCards.tsx
@@ -20,7 +20,7 @@ export const InfoCards = () => {
         content={isLoggedIn ? t('profile.banner.description.logged-in') : t('profile.banner.description.unlogged')}
         size="sm"
         buttonLabel={isLoggedIn ? t('profile.banner.link-text.logged-in') : t('profile.banner.link-text.unlogged')}
-        backgroundColor="var(--ds-color-secondary-1-dark)"
+        backgroundColor="var(--ds-color-primary-1-dark)"
         to={t('slugs.profile.index')}
         linkComponent={getLinkTo(
           isLoggedIn

--- a/src/routes/Search/Searchbar.tsx
+++ b/src/routes/Search/Searchbar.tsx
@@ -40,7 +40,7 @@ export const SearchBar = ({ scrollRef }: { scrollRef: React.RefObject<HTMLDivEle
   return (
     <div className="mb-5 flex scroll-m-11 flex-col gap-2" ref={scrollRef}>
       <form id={formId} className="flex items-center" onSubmit={onSubmit} noValidate>
-        <div className="flex w-full items-center rounded-md border border-border-form bg-white p-2 text-primary-gray">
+        <div className="border-border-form flex w-full items-center rounded-md border bg-white p-2 text-primary-gray">
           <input
             type="text"
             name="search"
@@ -76,7 +76,7 @@ export const SearchBar = ({ scrollRef }: { scrollRef: React.RefObject<HTMLDivEle
         </div>
       </form>
       {submitError && (
-        <div id={errorId} className="mt-2 block font-arial text-form-error text-alert-text-2" role="alert">
+        <div id={errorId} className="mt-2 block font-arial text-form-error text-alert-2" role="alert">
           {submitError}
         </div>
       )}

--- a/src/routes/Tool/Tool.tsx
+++ b/src/routes/Tool/Tool.tsx
@@ -259,7 +259,7 @@ const YourInfoGroup = ({ children }: { children: React.ReactNode }) => {
 };
 const YourInfoGroupSeparator = () => {
   const { lg } = useMediaQueries();
-  return lg ? null : <div className="mx-5 border-t-4 border-primary-light-2" />;
+  return lg ? null : <div className="mx-5 border-t-4 border-primary-5-light-2" />;
 };
 
 const YourInfo = () => {
@@ -300,7 +300,7 @@ const YourInfo = () => {
 
           <UpdateEhdotuksetAndTyomahdollisuudetButton
             id="tool-update-opportunities-button"
-            className={cx('rounded border-t-2', lg && 'border-primary-light-2', !lg && 'border-bg-gray')}
+            className={cx('rounded border-t-2', lg && 'border-primary-5-light-2', !lg && 'border-bg-gray')}
           />
         </YourInfoGroup>
 
@@ -316,7 +316,7 @@ const YourInfo = () => {
         <RateContent variant="kohtaanto" area="Kohtaanto työkalu" size="md" />
       </div>
 
-      <div className="flex flex-col gap-3 rounded-md bg-secondary-1-dark-2 px-5 py-6 text-white lg:mx-3">
+      <div className="flex flex-col gap-3 rounded-md bg-primary-1-dark-2 px-5 py-6 text-white lg:mx-3">
         <h2 className="text-heading-2-mobile sm:text-heading-2">
           {isLoggedIn ? t('profile.banner.title.logged-in') : t('profile.banner.title.unlogged')}
         </h2>

--- a/src/routes/Tool/components/Setting.tsx
+++ b/src/routes/Tool/components/Setting.tsx
@@ -42,7 +42,7 @@ export const Setting = ({
   return (
     <li
       className={cx(`py-3 ${className}`, {
-        'border-t-2 border-primary-light-2': !hideTopBorder,
+        'border-t-2 border-primary-5-light-2': !hideTopBorder,
         'pl-3': sm,
       })}
       data-testid={testId ?? triggerId}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
‼️ **Requires** Opetushallitus/jod-design-system/pull/584

- Update `@jod/design-system`
- Update color tokens usage


<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2133
