### PR TITLE
OPHJOD-3453: Add margin to SummaryStep

### DIFF
--- a/src/routes/Profile/Preferences/CvImport/SummaryStep.tsx
+++ b/src/routes/Profile/Preferences/CvImport/SummaryStep.tsx
@@ -8,6 +8,7 @@ import { DataImportTable } from '@/components/DataImportTable/DataImportTable';
 import type { CvImportConvertedData } from './utils';
 
 interface SectionProps {
+  className?: string;
   hasData: boolean;
   titleText: string;
   noDataText: string;
@@ -15,9 +16,16 @@ interface SectionProps {
   rows?: ExperienceTableRowData[];
 }
 
-const Section = ({ hasData, titleText: titleKey, noDataText, toggleAllSelectionText, rows }: SectionProps) => {
+const Section = ({
+  className,
+  hasData,
+  titleText: titleKey,
+  noDataText,
+  toggleAllSelectionText,
+  rows,
+}: SectionProps) => {
   return (
-    <div>
+    <div className={className}>
       <h2 className="mb-6 text-heading-2-mobile sm:text-heading-2">{titleKey}</h2>
       {hasData && rows && <DataImportTable rows={rows} toggleAllSelectionText={toggleAllSelectionText} />}
       {!hasData && <EmptyState text={noDataText} />}
@@ -73,6 +81,7 @@ const SummaryStep = ({ isLoading, convertedData }: SummaryStepProps) => {
             noDataText={t('preferences.cv-import.summary.activities.no-data')}
             toggleAllSelectionText={t('free-time-activities.theme-or-activity')}
             rows={convertedData?.activities}
+            className="mb-8"
           />
         </>
       )}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Add margin to SummaryStep
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3453
