### PR TITLE
OPHJOD-3506: Fix data-testid placement

### DIFF
--- a/src/routes/Profile/MyGoals/MyGoalsSection.tsx
+++ b/src/routes/Profile/MyGoals/MyGoalsSection.tsx
@@ -91,9 +91,8 @@ const MyGoalsSection = ({ tavoitteet }: MyGoalsSectionProps) => {
                     <p className="font-arial text-primary-gray" data-testid="goal-description">
                       {getLocalizedText(tavoite.kuvaus)}
                     </p>
-                    <p className="font-semibold text-secondary-gray sm:text-body-sm">
+                    <p className="font-semibold text-secondary-gray sm:text-body-sm" data-testid="goal-plans-count">
                       {t('profile.my-goals.n-plans', { count: tavoite.suunnitelmat?.length ?? 0 })}
-                      data-testid="goal-plans-count"
                     </p>
                   </div>
                 }


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Fix data-testid placement
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3506
