### PR TITLE
OPHJOD-3473: Remove Occupational group details from job opportunity

### DIFF
--- a/src/routes/JobOpportunity/JobOpportunity.tsx
+++ b/src/routes/JobOpportunity/JobOpportunity.tsx
@@ -215,7 +215,7 @@ const JobOpportunity = () => {
     {
       navTitle: t('job-opportunity.professional-group'),
       titleAppendix: getTranslation(ammattiryhma?.nimi),
-      content: <div className="font-arial">{getTranslation(ammattiryhma?.kuvaus)}</div>,
+      content: <></>,
       showDivider: false,
     },
     {


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
Remove Occupational group details from job opportunity. Show only title.
Old:
<img width="851" height="419" alt="Screenshot 2026-08-05 at 14 19 29" src="https://github.com/user-attachments/assets/265be876-94c9-4921-b64e-9b8135c85f8a" />
New:
<img width="723" height="185" alt="Screenshot 2026-08-05 at 14 19 34" src="https://github.com/user-attachments/assets/2fbf2e1b-bf68-4274-8458-d7560803211e" />

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3473
