### PR TITLE
OPHJOD-3509: Fix sorting+emphasis on filters on Tool

### DIFF
--- a/src/routes/Tool/ToolSettings.tsx
+++ b/src/routes/Tool/ToolSettings.tsx
@@ -6,7 +6,8 @@ import { Button, Modal, useMediaQueries } from '@jod/design-system';
 
 import { ModalComponentProps, useModal } from '@/hooks/useModal';
 import { FilterOpportunityType } from '@/routes/Tool/components/filters/FilterOpportunityType';
-import { useToolStore } from '@/stores/useToolStore';
+import { DEFAULT_PAINOTUS, useToolStore } from '@/stores/useToolStore';
+import { DEFAULT_SORTING } from '@/stores/useToolStore/ToolStoreModel';
 import { getFilterCount, noFiltersSelected } from '@/utils/FilterUtils';
 
 import { FilterSijainti } from './components/filters/FilterSijainti';
@@ -102,7 +103,11 @@ const ToolSettings = ({ onUpdate, ...rest }: ToolSettingsProps) => {
               size={sm ? 'lg' : 'sm'}
               onClick={resetSettings}
               label={t('tool.settings.reset')}
-              disabled={noFiltersSelected(filters)}
+              disabled={
+                noFiltersSelected(filters) &&
+                sorting === DEFAULT_SORTING &&
+                osaamisKiinnostusPainotus === DEFAULT_PAINOTUS
+              }
               testId="reset-settings-button"
             />
           </div>

--- a/src/stores/useToolStore/index.ts
+++ b/src/stores/useToolStore/index.ts
@@ -27,7 +27,7 @@ import { paginate } from '@/utils';
 import { mapKoulutusCodesToLabels } from '@/utils/codes/codes';
 
 const SUOSIKIT_PATH = '/api/profiili/suosikit';
-const DEFAULT_PAINOTUS = 50;
+export const DEFAULT_PAINOTUS = 50;
 
 let abortController = new AbortController();
 


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fix sorting and emphasis-slider filter on Tool's settings so that the enable/disable the footer's selection button.

## Screenshot
<img width="600" alt="SCR-20260807-iqeq-3" src="https://github.com/user-attachments/assets/1b3d2a1a-9389-4818-8b6f-ede7d2701750" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3509
