### PR TITLE
OPHJOD-3449: Update Goals to show only one at a time

### DIFF
--- a/src/i18n/yksilo/en.json
+++ b/src/i18n/yksilo/en.json
@@ -834,7 +834,7 @@
       "choose-favorite-description": "Choose a profession or employment opportunity from your favorites that you want to set as a goal",
       "choose-favorite-header": "Select goal from favourites",
       "competence-compare": "Compare competences",
-      "competence-description": "On the left, the competences required for your goal are listed. On the right, you can see what you already know. The information is based on your profile data.",
+      "competence-description": "On the left, the competences required for your goal are listed. On the right, you can see what you already know and what you can learn from the education options you have selected. Your own competences are based on your profile data.",
       "competence-requirement-for-goal": "Competence required for goal",
       "competences": "Competences",
       "custom-plan-competences-description": "Create your own option by first giving it a name and a short description. Then select the competences you want to achieve with the option.",
@@ -885,6 +885,7 @@
       "required-competences": "Competences required for the goal",
       "selected-competences": "Competences selected for my option",
       "set-to-goal": "Set as goal",
+      "show-goal": "Show goal",
       "title": "Goals",
       "update-modal-title": "Edit goal"
     },

--- a/src/i18n/yksilo/fi.json
+++ b/src/i18n/yksilo/fi.json
@@ -832,7 +832,7 @@
       "choose-favorite-description": "Valitse suosikeistasi ammatti tai työmahdollisuus, jonka haluat asettaa tavoitteeksi",
       "choose-favorite-header": "Valitse tavoite suosikeista",
       "competence-compare": "Osaamisvertailu",
-      "competence-description": "Vasemmalla on listattu tavoitteesi vaatimat osaamiset. Oikealla näet, mitä osaat jo. Tiedot perustuvat profiilitietoihisi.",
+      "competence-description": "Vasemmalla on listattu tavoitteesi vaatimat osaamiset. Oikealla näet, mitä osaat jo ja mitä voit oppia valitsemillasi koulutusvaihtoehdoilla. Omat osaamiset perustuvat profilitietoihisi.",
       "competence-requirement-for-goal": "Tavoitteen vaatima osaaminen",
       "competences": "Osaamista",
       "custom-plan-competences-description": "Valitse tavoitteeseen vaadittavista osaamisista ne, jotka aiot saavuttaa oman koulutusvaihtoehtosi avulla.",
@@ -883,6 +883,7 @@
       "required-competences": "Tavoitteeseen vaaditut osaamiset",
       "selected-competences": "Omaan vaihtoehtoon valitut osaamiset",
       "set-to-goal": "Aseta tavoitteeksi",
+      "show-goal": "Näytä tavoite",
       "title": "Tavoitteet",
       "update-modal-title": "Muokkaa tavoitetta"
     },

--- a/src/i18n/yksilo/sv.json
+++ b/src/i18n/yksilo/sv.json
@@ -833,7 +833,7 @@
       "choose-favorite-description": "Välj yrke eller arbetsmöjlighet från dina favoriter som du vill ställa in som mål",
       "choose-favorite-header": "Välj mål från favoriter",
       "competence-compare": "Kompetensjämförelse",
-      "competence-description": "Till vänster listas de kompetenser som krävs för ditt mål. Till höger kan du se vad du redan kan. Informationen baseras på dina profiluppgifter.",
+      "competence-description": "Till vänster listas de kompetenser som krävs för ditt mål. Till höger kan du se vad du redan kan och vad du kan lära dig från de utbildningsalternativ du har valt. Dina egna kompetenser baseras på dina profiluppgifter.",
       "competence-requirement-for-goal": "Kompetenskrav för mål",
       "competences": "Kompetenser",
       "custom-plan-competences-description": "Välj de kompetenser som krävs för målet och som du planerar att uppnå med ditt eget utbildningsalternativ.",
@@ -884,6 +884,7 @@
       "required-competences": "Kompetenser som krävs för målet",
       "selected-competences": "Valda kompetenser i egen alternativ",
       "set-to-goal": "Sätt som mål",
+      "show-goal": "Visa mål",
       "title": "Mål",
       "update-modal-title": "Redigera målet"
     },

--- a/src/routes/Profile/MyGoals/MyGoalsSection.tsx
+++ b/src/routes/Profile/MyGoals/MyGoalsSection.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLoaderData, useRevalidator } from 'react-router';
 import { useShallow } from 'zustand/shallow';
 
-import { Accordion, Button, useMediaQueries } from '@jod/design-system';
+import { Button, Select, useMediaQueries } from '@jod/design-system';
 
 import type { components } from '@/api/schema';
 import { OpportunityCard } from '@/components';
@@ -63,114 +63,114 @@ const MyGoalsSection = ({ tavoitteet }: MyGoalsSectionProps) => {
 
   const setTavoite = addPlanStore((state) => state.setTavoite);
 
-  const [openIndex, setOpenIndex] = React.useState<number | null>(0);
-  const toggleAccordion = (index: number) => {
-    setOpenIndex(openIndex === index ? null : index);
-  };
+  const goalOptions = tavoitteet.map((tavoite, i) => ({
+    value: String(tavoite.id ?? tavoite.mahdollisuusId ?? i),
+    label: getLocalizedText(tavoite.tavoite),
+  }));
+
+  const [selectedGoalValue, setSelectedGoalValue] = React.useState<string | undefined>(goalOptions[0]?.value);
+
+  const selectedTavoite = tavoitteet.find(
+    (tavoite, i) => String(tavoite.id ?? tavoite.mahdollisuusId ?? i) === selectedGoalValue,
+  );
 
   return (
     <div className="mb-5">
       <div className="mb-5 flex flex-col gap-6 px-5 sm:px-6 lg:pr-0 lg:pl-6" data-testid="my-goals-section">
-        {tavoitteet.map((tavoite, i) => {
-          const { mahdollisuusId, mahdollisuusTyyppi } = tavoite;
-          const details = getMahdollisuusDetails(mahdollisuusId);
-          const id = tavoite.id ?? mahdollisuusId ?? i;
-          const triggerId = `accordion-header-${id}`;
-          const contentId = `accordion-content-${id}`;
+        <Select
+          label={t('profile.my-goals.show-goal')}
+          options={goalOptions}
+          selected={selectedGoalValue}
+          onChange={setSelectedGoalValue}
+          placeholder={t('profile.my-goals.show-goal')}
+          testId="goal-select"
+        />
 
-          return (
-            <div key={id} className="flex flex-col rounded bg-white p-5 sm:p-6">
-              <Accordion
-                triggerId={triggerId}
-                ariaControls={contentId}
-                isOpen={openIndex === i}
-                setIsOpen={() => toggleAccordion(i)}
-                title={getLocalizedText(tavoite.tavoite)}
-                collapsedContent={
-                  <div className="mt-2 flex flex-col">
-                    <p className="font-arial text-primary-gray" data-testid="goal-description">
-                      {getLocalizedText(tavoite.kuvaus)}
-                    </p>
-                    <p className="font-semibold text-secondary-gray sm:text-body-sm" data-testid="goal-plans-count">
-                      {t('profile.my-goals.n-plans', { count: tavoite.suunnitelmat?.length ?? 0 })}
-                    </p>
-                  </div>
-                }
-                testId={`goal-accordion-${getLocalizedText(tavoite.tavoite)}`}
-              >
-                <section id={contentId}>
-                  <p className="mt-3 font-arial text-primary-gray" data-testid="goal-description">
-                    {getLocalizedText(tavoite.kuvaus)}
+        {selectedTavoite &&
+          (() => {
+            const { mahdollisuusId, mahdollisuusTyyppi } = selectedTavoite;
+            const details = getMahdollisuusDetails(mahdollisuusId);
+
+            return (
+              <div className="flex flex-col rounded bg-white p-5 sm:p-6">
+                <div className="flex flex-col gap-2 sm:gap-3">
+                  <h2
+                    className="font-poppins text-heading-3 text-primary-gray sm:text-heading-3-mobile"
+                    data-testid="goal-title"
+                  >
+                    {getLocalizedText(selectedTavoite.tavoite)}
+                  </h2>
+                  <p className="font-arial text-primary-gray" data-testid="goal-description">
+                    {getLocalizedText(selectedTavoite.kuvaus)}
                   </p>
-                  <div className="p-4">
-                    {details && mahdollisuusTyyppi && (
-                      <>
-                        <OpportunityCard
-                          to={`/${i18n.language}/${getTypeSlug(mahdollisuusTyyppi)}/${mahdollisuusId ?? ''}`}
-                          description={getLocalizedText(details.tiivistelma)}
-                          from="goal"
-                          ammattiryhma={details.ammattiryhma}
-                          ammattiryhmaNimet={loaderData?.ammattiryhmaNimet}
-                          name={getLocalizedText(details.otsikko)}
-                          mahdollisuusTyyppi={mahdollisuusTyyppi}
-                          mahdollisuusAlityyppi={getMahdollisuusAlityyppi(details)}
-                          kesto={details.kesto}
-                          yleisinKoulutusala={details.yleisinKoulutusala}
-                          headingLevel="h3"
-                          hideFavorite
-                          isActiveOpportunity={details.aktiivinen}
-                          borderClassName="border-2 border-border-gray"
-                        />
-                        <PlanList
-                          goal={tavoite}
-                          language={i18n.language}
-                          removeSuunnitelmaFromStore={removeSuunnitelmaFromStore}
-                        />
-                      </>
-                    )}
+                </div>
+                <div className="pt-6 sm:pt-7">
+                  {details && mahdollisuusTyyppi && (
+                    <>
+                      <OpportunityCard
+                        to={`/${i18n.language}/${getTypeSlug(mahdollisuusTyyppi)}/${mahdollisuusId ?? ''}`}
+                        description={getLocalizedText(details.tiivistelma)}
+                        from="goal"
+                        ammattiryhma={details.ammattiryhma}
+                        ammattiryhmaNimet={loaderData?.ammattiryhmaNimet}
+                        name={getLocalizedText(details.otsikko)}
+                        mahdollisuusTyyppi={mahdollisuusTyyppi}
+                        mahdollisuusAlityyppi={getMahdollisuusAlityyppi(details)}
+                        kesto={details.kesto}
+                        yleisinKoulutusala={details.yleisinKoulutusala}
+                        headingLevel="h3"
+                        hideFavorite
+                        isActiveOpportunity={details.aktiivinen}
+                        borderClassName="border-2 border-border-gray"
+                      />
+                      <PlanList
+                        goal={selectedTavoite}
+                        language={i18n.language}
+                        removeSuunnitelmaFromStore={removeSuunnitelmaFromStore}
+                      />
+                    </>
+                  )}
 
-                    <div className="mt-9 flex flex-col items-start gap-3 pl-3 sm:pl-4">
-                      <PlanCompetencesTable goal={tavoite} />
-                      <div className="flex w-full justify-end gap-5">
-                        <Button
-                          variant="gray"
-                          ariaHaspopup="dialog"
-                          size={'sm'}
-                          onClick={guardedAction(() => {
-                            setTavoite(tavoite);
-                            showModal(GoalModal, { mode: 'UPDATE', tavoite: tavoite });
-                          })}
-                          disabled={isLoading}
-                          label={sm ? t('profile.my-goals.modify-goal') : t('edit')}
-                          testId="modify-goal-button"
-                        />
-                        <Button
-                          label={t('profile.my-goals.delete-goal')}
-                          variant="white-delete"
-                          size={'sm'}
-                          ariaHaspopup="dialog"
-                          onClick={guardedAction(() => {
-                            showDialog({
-                              title: t('profile.my-goals.delete-goal'),
-                              description: t('profile.my-goals.delete-goal-description'),
-                              onConfirm: async () => {
-                                await deleteTavoite(tavoite.id!);
-                                await revalidator.revalidate();
-                              },
-                              testId: 'delete-goal-dialog',
-                            });
-                          })}
-                          disabled={!tavoite.id || isLoading}
-                          testId="delete-goal-button"
-                        />
-                      </div>
+                  <div className="mt-9 flex flex-col items-start gap-3 pl-3 sm:pl-4">
+                    <PlanCompetencesTable goal={selectedTavoite} />
+                    <div className="flex w-full justify-end gap-5">
+                      <Button
+                        variant="gray"
+                        ariaHaspopup="dialog"
+                        size={'sm'}
+                        onClick={guardedAction(() => {
+                          setTavoite(selectedTavoite);
+                          showModal(GoalModal, { mode: 'UPDATE', tavoite: selectedTavoite });
+                        })}
+                        disabled={isLoading}
+                        label={sm ? t('profile.my-goals.modify-goal') : t('edit')}
+                        testId="modify-goal-button"
+                      />
+                      <Button
+                        label={t('profile.my-goals.delete-goal')}
+                        variant="white-delete"
+                        size={'sm'}
+                        ariaHaspopup="dialog"
+                        onClick={guardedAction(() => {
+                          showDialog({
+                            title: t('profile.my-goals.delete-goal'),
+                            description: t('profile.my-goals.delete-goal-description'),
+                            onConfirm: async () => {
+                              await deleteTavoite(selectedTavoite.id!);
+                              await revalidator.revalidate();
+                            },
+                            testId: 'delete-goal-dialog',
+                          });
+                        })}
+                        disabled={!selectedTavoite.id || isLoading}
+                        testId="delete-goal-button"
+                      />
                     </div>
                   </div>
-                </section>
-              </Accordion>
-            </div>
-          );
-        })}
+                </div>
+              </div>
+            );
+          })()}
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update to show only one goal at a time, using dropdown.
- Uses the `Select` component which uses Radibutton style for items.

## Screenshot

<img width="600" alt="SCR-20260812-nimu-2" src="https://github.com/user-attachments/assets/ca3f53f4-a7ac-4d15-83d2-d3b47e635a87" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3449
